### PR TITLE
Fix scaling on high DPI monitors

### DIFF
--- a/gpt_computer_assistant/start.py
+++ b/gpt_computer_assistant/start.py
@@ -16,7 +16,8 @@ def start():
         set_profile(profile)
     
 
-    from .gpt_computer_assistant import QApplication, MainWindow, sys
+    from .gpt_computer_assistant import QApplication, MainWindow, sys, os
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
     app = QApplication(sys.argv)
     ex = MainWindow()
     sys.exit(app.exec_())


### PR DESCRIPTION
This is my first ever pull request, so bear with me here. I added a simple fix for high-res monitors, because the layout is pretty broken on my 4k monitor.

Before fix:
![image](https://github.com/onuratakan/gpt-computer-assistant/assets/13336171/12aefc09-76a2-4168-b679-5e846f311a9f)

After fix:
![image](https://github.com/onuratakan/gpt-computer-assistant/assets/13336171/9ecb16ca-b720-4511-8974-cdedda84256e)

As you can see, the layout is now fixed, however there is the issue of blurry button icons, which could probably be fixed with a simple upscaling of the icon assets. Feel free to add any changes you find necessary (especially those upscaled icon assets, if you need help upscaling do let me know).