### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
   <a href="#">
     <img src="https://github.com/user-attachments/assets/27778034-29f5-4a71-b696-4e3f70760b26" >
   </a>
@@ -11,9 +10,8 @@ Hi, this is an open source framework to build vertical AI agent. We just support
 
 <p>
 
-
-
   <p >
+    [![smithery badge](https://smithery.ai/badge/gpt-computer-assistant)](https://smithery.ai/server/gpt-computer-assistant)
     <a href="https://www.producthunt.com/posts/gpt-computer-assistant?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-gpt&#0045;computer&#0045;assistant" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=465468&theme=dark&period=daily" alt="GPT&#0032;Computer&#0032;Assistant - Create&#0032;intelligence&#0032;for&#0032;your&#0032;products | Product Hunt" width="200"  /></a>
     .
     <a href="https://discord.gg/qApFmWMt8x"><img alt="Static Badge" src="https://img.shields.io/badge/Discord-Join?style=social&logo=discord" width=120></a>
@@ -60,7 +58,7 @@ With [playground.gca.dev](https://playground.gca.dev/) you are ready to test and
 </p>
 
 # GPT Computer Assistant(GCA)
-GCA is an AI agent framework designed to make computer use across Windows, macOS, and Ubuntu. GCA enables you to replace repetitive, small-logic-based tasks worker to an AI. There is an really important potential that we believe. Whether you’re a developer, analyst, or IT professional, GCA can empower you to accomplish more in less time.
+GCA is an AI agent framework designed to make computer use across Windows, macOS, and Ubuntu. GCA enables you to replace repetitive, small-logic-based tasks worker to an AI. There is an really important potential that we believe. Whether you're a developer, analyst, or IT professional, GCA can empower you to accomplish more in less time.
 
 
 Imagine this:
@@ -97,7 +95,7 @@ GCA can replicate common user actions, such as:
 -	<b>Scrolling</b>: Navigate through documents or web pages.
 -	<b>Typing</b>: Enter text into forms or other input fields.
 ### 2.	Advanced Capabilities:
-Through MCP and GCA’s own modules, it achieves tasks that go beyond standard human interaction, such as:
+Through MCP and GCA's own modules, it achieves tasks that go beyond standard human interaction, such as:
 
 -	<b>Updating dependencies</b> of a project in seconds.
 -	<b>Analyzing entire database</b> tables to locate specific data almost instantly.
@@ -124,6 +122,16 @@ Through MCP and GCA’s own modules, it achieves tasks that go beyond standard h
 </p>
 
 ## Using GCA.dev Cloud
+
+### Installing via Smithery
+
+To install GPT Computer Assistant for Claude Desktop automatically via [Smithery](https://smithery.ai/server/gpt-computer-assistant):
+
+```bash
+npx -y @smithery/cli install gpt-computer-assistant --client claude
+```
+
+### Installing via pip
 
 <b>Installation</b>
 ```console

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ With [playground.gca.dev](https://playground.gca.dev/) you are ready to test and
 </p>
 
 # GPT Computer Assistant(GCA)
-GCA is an AI agent framework designed to make computer use across Windows, macOS, and Ubuntu. GCA enables you to replace repetitive, small-logic-based tasks worker to an AI. There is an really important potential that we believe. Whether you're a developer, analyst, or IT professional, GCA can empower you to accomplish more in less time.
+GCA is an AI agent framework designed to make computer use across Windows, macOS, and Ubuntu. GCA enables you to replace repetitive, small-logic-based tasks worker to an AI. There is an really important potential that we believe. Whether you’re a developer, analyst, or IT professional, GCA can empower you to accomplish more in less time.
 
 
 Imagine this:
@@ -95,7 +95,7 @@ GCA can replicate common user actions, such as:
 -	<b>Scrolling</b>: Navigate through documents or web pages.
 -	<b>Typing</b>: Enter text into forms or other input fields.
 ### 2.	Advanced Capabilities:
-Through MCP and GCA's own modules, it achieves tasks that go beyond standard human interaction, such as:
+Through MCP and GCA’s own modules, it achieves tasks that go beyond standard human interaction, such as:
 
 -	<b>Updating dependencies</b> of a project in seconds.
 -	<b>Analyzing entire database</b> tables to locate specific data almost instantly.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Hi, this is an open source framework to build vertical AI agent. We just support
 <p>
 
   <p >
-    [![smithery badge](https://smithery.ai/badge/gpt-computer-assistant)](https://smithery.ai/server/gpt-computer-assistant)
     <a href="https://www.producthunt.com/posts/gpt-computer-assistant?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-gpt&#0045;computer&#0045;assistant" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=465468&theme=dark&period=daily" alt="GPT&#0032;Computer&#0032;Assistant - Create&#0032;intelligence&#0032;for&#0032;your&#0032;products | Product Hunt" width="200"  /></a>
     .
     <a href="https://discord.gg/qApFmWMt8x"><img alt="Static Badge" src="https://img.shields.io/badge/Discord-Join?style=social&logo=discord" width=120></a>
@@ -21,13 +20,12 @@ Hi, this is an open source framework to build vertical AI agent. We just support
 
 
 
-
   <p>
   <a href="https://www.python.org/">
   <img src="https://img.shields.io/badge/Made%20with-Python-1f425f.svg" alt="Made_with_python">
   </a>
-  .
   <img src="https://static.pepy.tech/personalized-badge/gpt-computer-assistant?period=total&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20Downloads" alt="pypi_downloads">
+  <a href="https://smithery.ai/server/gpt-computer-assistant"><img alt="Smithery Badge" src="https://smithery.ai/badge/gpt-computer-assistant"></a>
   </p>
 
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install GPT Computer Assistant for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/gpt-computer-assistant

Let me know if any tweaks have to be made!