### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Upsonic offers a cutting-edge enterprise-ready framework where you can orchestra
 
 ## Installation
 
+### Installing via Smithery
+
+To install GPT Computer Assistant for Claude Desktop automatically via [Smithery](https://smithery.ai/server/gpt-computer-assistant):
+
+```bash
+npx -y @smithery/cli install gpt-computer-assistant --client claude
+```
+
+### Manual Installation
 ```bash
 pip install upsonic
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,32 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openaiApiKey
+    properties:
+      openaiApiKey:
+        type: string
+        description: API key for OpenAI.
+      anthropicApiKey:
+        type: string
+        description: API key for Anthropic.
+      azureOpenaiApiKey:
+        type: string
+        description: API key for Azure OpenAI.
+      awsAccessKeyId:
+        type: string
+        description: AWS Access Key ID.
+      awsSecretAccessKey:
+        type: string
+        description: AWS Secret Access Key.
+      awsRegion:
+        type: string
+        description: AWS Region.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command: 'docker', args: ['run', '--rm', '-e', `OPENAI_API_KEY=${config.openaiApiKey}`, '-e', `ANTHROPIC_API_KEY=${config.anthropicApiKey}`, '-e', `AZURE_OPENAI_API_KEY=${config.azureOpenaiApiKey}`, '-e', `AWS_ACCESS_KEY_ID=${config.awsAccessKeyId}`, '-e', `AWS_SECRET_ACCESS_KEY=${config.awsSecretAccessKey}`, '-e', `AWS_REGION=${config.awsRegion}`, 'upsonic-image']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/gpt-computer-assistant?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂