### PR TITLE
chore: Pin pydantic version to 2.10.4 in pyproject.toml and uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "dill>=0.3.9",
     "httpx>=0.27.2",
     "psutil==6.1.1",
-    "pydantic>=2.10.4",
+    "pydantic==2.10.4",
     "rich>=13.9.4",
     "sentry-sdk[opentelemetry]>=2.19.2",
     "toml>=0.10.2",

--- a/uv.lock
+++ b/uv.lock
@@ -3256,7 +3256,7 @@ requires-dist = [
     { name = "pipmaster", marker = "extra == 'rag'", specifier = ">=0.5.1" },
     { name = "psutil", specifier = "==6.1.1" },
     { name = "pyautogui", specifier = ">=0.9.54" },
-    { name = "pydantic", specifier = ">=2.10.4" },
+    { name = "pydantic", specifier = "==2.10.4" },
     { name = "pydantic-ai", specifier = "==0.0.45" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },


### PR DESCRIPTION
Fixes: #314