### PR TITLE
Add support for OPENAI_API_BASE

### DIFF
--- a/src/upsonic/client/storage/storage.py
+++ b/src/upsonic/client/storage/storage.py
@@ -17,6 +17,7 @@ class ClientConfig(BaseModel):
     DEFAULT_LLM_MODEL: str = Field(default="openai/gpt-4o")
     
     OPENAI_API_KEY: str | None = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    OPENAI_API_BASE: str | None = Field(default_factory=lambda: os.getenv("OPENAI_API_BASE"))
 
     ANTHROPIC_API_KEY: str | None = Field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY"))
     

--- a/src/upsonic/server/level_utilized/utility.py
+++ b/src/upsonic/server/level_utilized/utility.py
@@ -339,13 +339,14 @@ async def handle_compression_retry(prompt, images, tools, llm_model, response_fo
     except Exception as e:
         raise e  # Re-raise for consistent error handling
 
-def _create_openai_client(api_key_name="OPENAI_API_KEY"):
+def _create_openai_client(api_key_name="OPENAI_API_KEY", base_url_name="OPENAI_API_BASE"):
     """Helper function to create an OpenAI client with the specified API key."""
     api_key = Configuration.get(api_key_name)
     if not api_key:
         return None, {"status_code": 401, "detail": f"No API key provided. Please set {api_key_name} in your configuration."}
+    base_url = Configuration.get(base_url_name)
     
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
     return client, None
 
 def _create_azure_openai_client():

--- a/src/upsonic/storage/configuration.py
+++ b/src/upsonic/storage/configuration.py
@@ -128,6 +128,7 @@ class ConfigManager:
 Configuration = ConfigManager()
 
 Configuration.initialize("OPENAI_API_KEY")
+Configuration.initialize("OPENAI_API_BASE")
 Configuration.initialize("ANTHROPIC_API_KEY")
 Configuration.initialize("AZURE_OPENAI_ENDPOINT")
 Configuration.initialize("AZURE_OPENAI_API_VERSION")


### PR DESCRIPTION
This change allows users to specify an alternative OPENAI_API_BASE in order to be able to utilize
OpenAI-compatible APIs. This change does not include the additional work that would be necessary
to specify custom models, but many OpenAI-compatible APIs (like LMStudio) ignore the model anyway.