### PR TITLE
feat: Running tools without Base Class

### DIFF
--- a/src/upsonic/tools/base/__init__.py
+++ b/src/upsonic/tools/base/__init__.py
@@ -1,4 +1,5 @@
 from .toolkit import Toolkit
 from .tool import Tool
+from .function_toolkit import FunctionToolkit
 
-__all__ = ["Toolkit", "Tool"]
+__all__ = ["Toolkit", "Tool", "FunctionToolkit"]

--- a/src/upsonic/tools/base/function_toolkit.py
+++ b/src/upsonic/tools/base/function_toolkit.py
@@ -1,0 +1,59 @@
+from typing import Any, Callable, List, Optional
+import inspect
+
+
+class FunctionToolkit:
+    """Toolkit wrapper for standalone decorated functions"""
+
+    def __init__(self, func: Callable, name: Optional[str] = None):
+        """
+        Initialize the toolkit with a single function.
+
+        Args:
+            func: The decorated function to wrap
+            name: Optional name for the toolkit
+        """
+        # Store original function without making it accessible as an attribute
+        self._original_func = func
+        self._name = name or f"{func.__name__}Toolkit"
+
+        # Create a bound method that accepts only keyword arguments but preserves signature
+        def bound_method(**kwargs):
+            return func(**kwargs)
+
+        # Copy function attributes to the bound method
+        bound_method.__name__ = func.__name__
+        bound_method.__doc__ = func.__doc__
+        bound_method._is_tool = True
+        bound_method._tool_description = getattr(func, "_tool_description", None)
+
+        # Preserve the original function's signature for proper schema generation
+        bound_method.__signature__ = inspect.signature(func)
+        bound_method.__annotations__ = func.__annotations__
+
+        # Set the bound method as an attribute and store reference for functions()
+        setattr(self, func.__name__, bound_method)
+        self._bound_method = bound_method
+
+    def __control__(self) -> bool:
+        """Validate that the toolkit is ready to use."""
+        return True
+
+    @property
+    def name(self) -> str:
+        """Get the toolkit name."""
+        return self._name
+
+    def functions(self) -> List[Any]:
+        """Return the list of tool functions - only the bound method."""
+        return [self._bound_method]
+
+    def get_description(self) -> str:
+        """Return a description of what this toolkit does."""
+        description = (
+            getattr(self._original_func, "_tool_description", None)
+            or self._original_func.__doc__
+        )
+        return (
+            description or f"Toolkit containing {self._original_func.__name__} function"
+        )

--- a/src/upsonic/tools/decorators/tool_decorator.py
+++ b/src/upsonic/tools/decorators/tool_decorator.py
@@ -135,7 +135,8 @@ def tool(func: Optional[Callable] = None, *, description: Optional[str] = None):
 
     def decorator(f):
         f._is_tool = True
-        f._tool_description = description
+        # Get the description from the function docstring or the description argument
+        f._tool_description = description or f.__doc__
 
         return f
 


### PR DESCRIPTION
# Overview  
This PR implements the ability to run tools without relying on the *Toolkit* base class.  
I found this usage more appropriate from the user's perspective.  
It is especially suitable for quickly building PoCs (Proof of Concepts).

# Example  
```python
@tool(description="Get warehouse stock information for a product")
def get_stock_info(product_name: str):
    return f"The stock of {product_name} is 100 units"


@tool
def calculate_discount(
    product_name: str, original_price: float, discount_percent: float
):
    """
    Calculate discount price for a product

    Args:
        product_name: The name of the product  
        original_price: The original price of the product  
        discount_percent: The discount percentage  
    """
    discount_amount = original_price * (discount_percent / 100)
    final_price = original_price - discount_amount
    return f"{product_name} original price: ${original_price:.2f}, discount: {discount_percent}%, final price: ${final_price:.2f}"


def main():
    agent = Agent(
        "Warehouse Assistant",
        model="openrouter/google/gemini-2.5-pro-preview",  # type: ignore
    )
    task2 = Task(
        description="First use get_stock_info tool for 'Laptop', then use calculate_discount tool for product_name='Laptop', original_price=999.99, discount_percent=15",
        tools=[get_stock_info, calculate_discount],
    )

    result2 = agent.print_do(task2)

    print(result2)
```

The framework now supports this style of usage.

Additionally, the @tool decorator was refactored.
You can now omit the description argument — it will automatically use the function's docstring if available.

```python
def decorator(f):
    f._is_tool = True
    # Get the description from the function docstring or the description argument
    f._tool_description = description or f.__doc__
```

--- 

Closes #392 