### PR TITLE
refactor: Removed unnecessary prints

### DIFF
--- a/src/upsonic/tools/processor.py
+++ b/src/upsonic/tools/processor.py
@@ -229,7 +229,6 @@ class ToolProcessor:
 
             setattr(behavioral_wrapper, '_upsonic_stop_after_call', config.stop_after_tool_call)
             setattr(behavioral_wrapper, '_upsonic_show_result', config.show_result)
-            print("FUNC DICT: ", func_dict)
 
             return func_dict
         return behavioral_wrapper

--- a/src/upsonic/utils/tool_usage.py
+++ b/src/upsonic/utils/tool_usage.py
@@ -23,7 +23,6 @@ def tool_usage(model_response, task):
 
         # Convert to list format
         tool_usage_value = list(tool_calls_map.values())
-        print("TOOL CALL MAP: ", tool_calls_map)
         # Store tool calls in the task
         for tool_call in tool_usage_value:
             task.add_tool_call(tool_call)

--- a/tests/test_task_function_tool.py
+++ b/tests/test_task_function_tool.py
@@ -16,7 +16,6 @@ class CallTracker:
         """
         self.called_with = (a, b)
         self.call_count += 1
-        print(f"[DEBUG] sum() called with: {a}, {b}")
         return a + b
 
 
@@ -35,10 +34,6 @@ class AgentToolTestCase(TestCase):
         agent = Agent(name="Sum Agent", model="openai/gpt-4o")
 
         result = agent.do(task)
-
-        print(f"[DEBUG] Agent result: {result}")
-        print(f"[DEBUG] Function call count: {tracker.call_count}")
-        print(f"[DEBUG] Called with: {tracker.called_with}")
 
         # Use unittest assertions instead of plain assert
         self.assertEqual(tracker.call_count, 1, "The tool function was not called exactly once.")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove debug print statements to clean up the codebase.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-f8c6387b-0e97-4405-946c-cbc8c7fbe9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8c6387b-0e97-4405-946c-cbc8c7fbe9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>