### PR TITLE
Add Authorization Token Support for MCPServerSSE

### DIFF
--- a/src/upsonic/tools/processor.py
+++ b/src/upsonic/tools/processor.py
@@ -235,7 +235,11 @@ class ToolProcessor:
                 is_mcp_tool = False
                 if hasattr(tool_item, 'url'):
                     url = getattr(tool_item, 'url')
-                    the_mcp_server = MCPServerSSE(url)
+                    token = getattr(tool_item, 'token', None)
+                    headers = {}
+                    if token:
+                        headers['Authorization'] = f'Bearer {token}'
+                    the_mcp_server = MCPServerSSE(url, headers=headers)
                     yield (None, the_mcp_server)
                     is_mcp_tool = True
                 elif hasattr(tool_item, 'command'):


### PR DESCRIPTION
### Overview:
This PR adds support for including an Authorization token when initializing `MCPServerSSE` in `normalize_and_process` function.

### Changes:
- Modified `normalize_and_process` to check if the tool item has a `token` attribute.
- If a token is present, it adds an `Authorization` header with the Bearer token.
- If no token is provided, the connection works as it did before, with no header.
