### PR TITLE
chore: make mcp and fastmcp optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "rich>=13.9.4",
     "sentry-sdk[opentelemetry]>=2.35.0",
     "toml>=0.10.2",
-    "uv>=0.5.20",
     "python-dotenv>=1.0.1",
     "uvicorn>=0.34.0",
     "nest-asyncio>=1.6.0",
@@ -316,6 +315,7 @@ dev = [
     "pytest-asyncio>=0.25.1",
     "pytest-timeout>=2.3.1",
     "tomlkit>=0.13.3",
+    "uv>=0.5.20",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "sentry-sdk[opentelemetry]>=2.35.0",
     "toml>=0.10.2",
     "uv>=0.5.20",
-    "mcp[cli]>=1.26.0",
     "python-dotenv>=1.0.1",
     "uvicorn>=0.34.0",
     "nest-asyncio>=1.6.0",
@@ -39,10 +38,13 @@ dependencies = [
     "genai-prices>=0.0.38",
     "protobuf>=5.27.2,<6.0.0",
     "cloudpickle>=3.1.2",
-    "fastmcp>=2.14.5",
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp[cli]>=1.26.0",
+    "fastmcp>=2.14.5",
+]
 chroma = [
     "chromadb>=1.0.20; python_version < '3.14'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "sentry-sdk[opentelemetry]>=2.35.0",
     "toml>=0.10.2",
     "uv>=0.5.20",
-    "mcp[cli]>=1.26.0",
     "python-dotenv>=1.0.1",
     "uvicorn>=0.34.0",
     "nest-asyncio>=1.6.0",
@@ -39,10 +38,13 @@ dependencies = [
     "genai-prices>=0.0.38",
     "protobuf>=5.27.2,<6.0.0",
     "cloudpickle>=3.1.2",
-    "fastmcp>=2.14.5",
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp[cli]>=1.26.0",
+    "fastmcp>=2.14.5",
+]
 asqav = [
     "asqav>=0.2.21",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 mcp = [
     "mcp[cli]>=1.26.0",
     "fastmcp>=2.14.5",
+]  
 asqav = [
     "asqav>=0.2.21",
 ]

--- a/src/upsonic/agent/agent.py
+++ b/src/upsonic/agent/agent.py
@@ -4248,7 +4248,15 @@ class Agent(BaseAgent):
         Returns:
             A :class:`fastmcp.FastMCP` server instance ready to ``.run()``.
         """
-        from fastmcp import FastMCP as _FastMCP
+        try:
+            from fastmcp import FastMCP as _FastMCP  # type: ignore[import-not-found]
+        except ImportError:
+            from upsonic.utils.printing import import_error
+            import_error(
+                package_name="fastmcp",
+                install_command="pip install 'upsonic[mcp]'",
+                feature_name="Agent.as_mcp() (expose agent as an MCP server)",
+            )
 
         server_name: str = name or self.name or "Upsonic Agent"
         server: _FastMCP = _FastMCP(server_name)

--- a/src/upsonic/team/team.py
+++ b/src/upsonic/team/team.py
@@ -689,7 +689,15 @@ class Team:
         Returns:
             A :class:`fastmcp.FastMCP` server instance ready to ``.run()``.
         """
-        from fastmcp import FastMCP as _FastMCP
+        try:
+            from fastmcp import FastMCP as _FastMCP  # type: ignore[import-not-found]
+        except ImportError:
+            from upsonic.utils.printing import import_error
+            import_error(
+                package_name="fastmcp",
+                install_command="pip install 'upsonic[mcp]'",
+                feature_name="Team.as_mcp() (expose team as an MCP server)",
+            )
 
         server_name: str = name or self.name or "Upsonic Team"
         server: _FastMCP = _FastMCP(server_name)

--- a/src/upsonic/tools/mcp.py
+++ b/src/upsonic/tools/mcp.py
@@ -17,18 +17,49 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import httpx
-from mcp import types as mcp_types
-from mcp.client.session import ClientSession
-from mcp.client.sse import sse_client
-from mcp.client.stdio import StdioServerParameters, stdio_client
 
 from upsonic.tools.base import Tool, ToolMetadata
 
+# The `mcp` SDK is an optional extra (install with `pip install upsonic[mcp]`).
+# We let the module import succeed without it so that downstream isinstance
+# checks (e.g. processor.py) keep working; instantiating MCPHandler / MultiMCPHandler
+# without the SDK raises a clear ImportError instead.
 try:
-    from mcp.client.streamable_http import streamable_http_client
-    HAS_STREAMABLE_HTTP = True
+    from mcp import types as mcp_types  # type: ignore[import-not-found]
+    from mcp.client.session import ClientSession  # type: ignore[import-not-found]
+    from mcp.client.sse import sse_client  # type: ignore[import-not-found]
+    from mcp.client.stdio import StdioServerParameters, stdio_client  # type: ignore[import-not-found]
+    _MCP_AVAILABLE = True
 except ImportError:
+    _MCP_AVAILABLE = False
+    mcp_types = None  # type: ignore[assignment]
+    ClientSession = None  # type: ignore[assignment,misc]
+    sse_client = None  # type: ignore[assignment]
+    stdio_client = None  # type: ignore[assignment]
+    StdioServerParameters = None  # type: ignore[assignment,misc]
+
+if _MCP_AVAILABLE:
+    try:
+        from mcp.client.streamable_http import streamable_http_client  # type: ignore[import-not-found]
+        HAS_STREAMABLE_HTTP = True
+    except ImportError:
+        HAS_STREAMABLE_HTTP = False
+        streamable_http_client = None  # type: ignore[assignment]
+else:
     HAS_STREAMABLE_HTTP = False
+    streamable_http_client = None  # type: ignore[assignment]
+
+
+def _require_mcp() -> None:
+    """Raise a friendly ImportError if the optional `mcp` SDK is missing."""
+    if _MCP_AVAILABLE:
+        return
+    from upsonic.utils.printing import import_error
+    import_error(
+        package_name="mcp",
+        install_command="pip install 'upsonic[mcp]'",
+        feature_name="MCP (Model Context Protocol) tool integration",
+    )
 
 
 _MCP_SECURITY_WARNING_EMITTED = False
@@ -235,6 +266,7 @@ class MCPHandler:
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "MCPHandler":
+        _require_mcp()
         _emit_mcp_security_warning()
         return super().__new__(cls)
 
@@ -779,6 +811,7 @@ class MultiMCPHandler:
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "MultiMCPHandler":
+        _require_mcp()
         _emit_mcp_security_warning()
         return super().__new__(cls)
 

--- a/uv.lock
+++ b/uv.lock
@@ -8830,11 +8830,9 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "cloudpickle" },
-    { name = "fastmcp" },
     { name = "genai-prices" },
     { name = "griffe" },
     { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "protobuf" },
@@ -8953,6 +8951,10 @@ mail-interface = [
 markdown-loader = [
     { name = "markdown-it-py" },
     { name = "python-frontmatter" },
+]
+mcp = [
+    { name = "fastmcp" },
+    { name = "mcp", extra = ["cli"] },
 ]
 mem0-storage = [
     { name = "mem0ai" },
@@ -9161,7 +9163,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'slack-interface'", specifier = ">=0.128.0" },
     { name = "fastapi", marker = "extra == 'web'" },
     { name = "fastembed", marker = "python_full_version < '3.14' and extra == 'embeddings'", specifier = ">=0.7.3" },
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.14.5" },
     { name = "firecrawl-py", marker = "extra == 'custom-tools'", specifier = ">=4.14.1" },
     { name = "genai-prices", specifier = ">=0.0.38" },
     { name = "genai-prices", marker = "extra == 'tools'", specifier = ">=0.0.29" },
@@ -9189,7 +9191,7 @@ requires-dist = [
     { name = "lxml", marker = "extra == 'xml-loader'", specifier = ">=4.9.1" },
     { name = "markdown-it-py", marker = "extra == 'loaders'", specifier = ">=4.0.0" },
     { name = "markdown-it-py", marker = "extra == 'markdown-loader'", specifier = ">=4.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0-storage'", specifier = ">=0.1.116" },
     { name = "mistralai", marker = "extra == 'models'", specifier = ">=1.9.11" },
     { name = "motor", marker = "extra == 'mongo-storage'", specifier = ">=3.7.1" },
@@ -9291,7 +9293,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'models'", specifier = ">=1.4.0" },
     { name = "yfinance", marker = "extra == 'tools'", specifier = ">=0.2.66" },
 ]
-provides-extras = ["chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
+provides-extras = ["mcp", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -339,6 +339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asqav"
+version = "0.2.21"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0e/9c84b2c8bf5587e44f7cbf52aa07208fff1c118ce85040075d978a5d36b1/asqav-0.2.21.tar.gz", hash = "sha256:a0cf7627e0be29990dd38174e50c41c33f00708d057fe1926c56ea90f369a0cb", size = 63278, upload-time = "2026-04-25T16:56:05.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/df/89e7ca0fc5ca7fa12d3c82e23ed05cd8933b203fc07c7be709d94bcb2cf7/asqav-0.2.21-py3-none-any.whl", hash = "sha256:e88d8ba840bdd796d13309cf1c6e1df66eddda647c3f48b36ab52597898bdcff", size = 76435, upload-time = "2026-04-25T16:56:04.364Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -8854,6 +8863,9 @@ dependencies = [
 apify-tool = [
     { name = "apify-client" },
 ]
+asqav = [
+    { name = "asqav" },
+]
 chroma = [
     { name = "chromadb", marker = "python_full_version < '3.14'" },
 ]
@@ -9131,6 +9143,7 @@ requires-dist = [
     { name = "anyio", marker = "extra == 'models'", specifier = ">=4.10.0" },
     { name = "apify-client", marker = "extra == 'apify-tool'", specifier = ">=1.8.1" },
     { name = "apify-client", marker = "extra == 'custom-tools'", specifier = ">=1.8.1" },
+    { name = "asqav", marker = "extra == 'asqav'", specifier = ">=0.2.21" },
     { name = "asyncpg", marker = "extra == 'postgres-storage'", specifier = ">=0.30.0" },
     { name = "azure-core", marker = "extra == 'embeddings'", specifier = ">=1.35.1" },
     { name = "azure-core", marker = "extra == 'models'", specifier = ">=1.35.1" },
@@ -9293,7 +9306,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'models'", specifier = ">=1.4.0" },
     { name = "yfinance", marker = "extra == 'tools'", specifier = ">=0.2.66" },
 ]
-provides-extras = ["mcp", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
+provides-extras = ["mcp", "asqav", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -8855,7 +8855,6 @@ dependencies = [
     { name = "toml" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
-    { name = "uv" },
     { name = "uvicorn" },
 ]
 
@@ -9125,6 +9124,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "tomlkit" },
+    { name = "uv" },
 ]
 
 [package.metadata]
@@ -9297,7 +9297,6 @@ requires-dist = [
     { name = "upsonic", extras = ["postgres-storage"], marker = "extra == 'storage'" },
     { name = "upsonic", extras = ["redis-storage"], marker = "extra == 'storage'" },
     { name = "upsonic", extras = ["sqlite-storage"], marker = "extra == 'storage'" },
-    { name = "uv", specifier = ">=0.5.20" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.35.0" },
     { name = "weaviate-client", marker = "extra == 'vectordb'", specifier = ">=4.16.9" },
@@ -9316,6 +9315,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.1" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "tomlkit", specifier = ">=0.13.3" },
+    { name = "uv", specifier = ">=0.5.20" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -339,15 +339,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asqav"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/98/caa933c09c5585546d952274f3faec9392223a3b0de17e0dbec06b156ab5/asqav-0.3.1.tar.gz", hash = "sha256:75b9e00498ef5a338faf2d2757928d25e07476494d141f1a120602ae49156640", size = 62867, upload-time = "2026-04-29T21:05:42.133Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/cc/d688857eeecec9bdfd7b50989355b9f5e4e6a8c655736b9e7d928ec2b274/asqav-0.3.1-py3-none-any.whl", hash = "sha256:160474187a952ad00fafa8a2610d4a992f4568823bdd312e88095662f4b9bfe9", size = 77544, upload-time = "2026-04-29T21:05:40.513Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -8839,11 +8830,9 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "cloudpickle" },
-    { name = "fastmcp" },
     { name = "genai-prices" },
     { name = "griffe" },
     { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "protobuf" },
@@ -8864,9 +8853,6 @@ dependencies = [
 [package.optional-dependencies]
 apify-tool = [
     { name = "apify-client" },
-]
-asqav = [
-    { name = "asqav" },
 ]
 chroma = [
     { name = "chromadb", marker = "python_full_version < '3.14'" },
@@ -8965,6 +8951,10 @@ mail-interface = [
 markdown-loader = [
     { name = "markdown-it-py" },
     { name = "python-frontmatter" },
+]
+mcp = [
+    { name = "fastmcp" },
+    { name = "mcp", extra = ["cli"] },
 ]
 mem0-storage = [
     { name = "mem0ai" },
@@ -9141,7 +9131,6 @@ requires-dist = [
     { name = "anyio", marker = "extra == 'models'", specifier = ">=4.10.0" },
     { name = "apify-client", marker = "extra == 'apify-tool'", specifier = ">=1.8.1" },
     { name = "apify-client", marker = "extra == 'custom-tools'", specifier = ">=1.8.1" },
-    { name = "asqav", marker = "extra == 'asqav'", specifier = ">=0.2.21" },
     { name = "asyncpg", marker = "extra == 'postgres-storage'", specifier = ">=0.30.0" },
     { name = "azure-core", marker = "extra == 'embeddings'", specifier = ">=1.35.1" },
     { name = "azure-core", marker = "extra == 'models'", specifier = ">=1.35.1" },
@@ -9174,7 +9163,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'slack-interface'", specifier = ">=0.128.0" },
     { name = "fastapi", marker = "extra == 'web'" },
     { name = "fastembed", marker = "python_full_version < '3.14' and extra == 'embeddings'", specifier = ">=0.7.3" },
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.14.5" },
     { name = "firecrawl-py", marker = "extra == 'custom-tools'", specifier = ">=4.14.1" },
     { name = "genai-prices", specifier = ">=0.0.38" },
     { name = "genai-prices", marker = "extra == 'tools'", specifier = ">=0.0.29" },
@@ -9202,7 +9191,7 @@ requires-dist = [
     { name = "lxml", marker = "extra == 'xml-loader'", specifier = ">=4.9.1" },
     { name = "markdown-it-py", marker = "extra == 'loaders'", specifier = ">=4.0.0" },
     { name = "markdown-it-py", marker = "extra == 'markdown-loader'", specifier = ">=4.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0-storage'", specifier = ">=0.1.116" },
     { name = "mistralai", marker = "extra == 'models'", specifier = ">=1.9.11" },
     { name = "motor", marker = "extra == 'mongo-storage'", specifier = ">=3.7.1" },
@@ -9304,7 +9293,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'models'", specifier = ">=1.4.0" },
     { name = "yfinance", marker = "extra == 'tools'", specifier = ">=0.2.66" },
 ]
-provides-extras = ["asqav", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
+provides-extras = ["mcp", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Moves `mcp[cli]` and `fastmcp` out of required dependencies into a new `[mcp]` optional extra. `tools/mcp.py` imports are guarded so the module loads without the SDK; `MCPHandler`/`MultiMCPHandler` and `Agent`/`Team.as_mcp()` raise a clear `ImportError` pointing at `pip install 'upsonic[mcp]'` when used without the extra.