### PR TITLE
fix(chat,messages): tolerate trailing junk in tool args and reset tas…

### DIFF
--- a/src/upsonic/chat/chat.py
+++ b/src/upsonic/chat/chat.py
@@ -770,7 +770,18 @@ class Chat:
         """Handle blocking invocation."""
         from upsonic.run.agent.output import AgentRunOutput as AgentRunOutputConcrete
 
+        attempt_counter = {"n": 0}
+
         async def _execute() -> Union[str, InvokeResult]:
+            if attempt_counter["n"] > 0:
+                # Reset task state so the next attempt is treated as a fresh
+                # run. Without this, do_async's _validate_task_for_new_run
+                # would short-circuit with "Task is already completed" once
+                # the previous attempt's pipeline marked the task.
+                task.status = None
+                task.run_id = None
+            attempt_counter["n"] += 1
+
             if self.debug and self.debug_level >= 2:
                 from upsonic.utils.printing import debug_log_level2
                 debug_log_level2(
@@ -782,7 +793,7 @@ class Chat:
                     user_id=self.user_id,
                     task_description=task.description[:300] if task.description else None,
                 )
-            
+
             if return_run_output:
                 result = await self.agent.do_async(task, debug=self.debug, return_output=True, **kwargs)
                 if not isinstance(result, AgentRunOutputConcrete):
@@ -837,9 +848,17 @@ class Chat:
         async def _stream_with_retry() -> AsyncIterator[str]:
             last_exception = None
             stream_generator = None
-            
+
             try:
                 for attempt in range(self._retry_attempts + 1):
+                    if attempt > 0:
+                        # Reset task state so the next attempt is treated as a
+                        # fresh run. The previous attempt's pipeline may have
+                        # synced a completed/error status onto the task; without
+                        # this reset, _validate_task_for_new_run would short-
+                        # circuit with "Task is already completed".
+                        task.status = None
+                        task.run_id = None
                     try:
                         stream_generator = _execute_streaming()
                         async for chunk in stream_generator:
@@ -853,7 +872,7 @@ class Chat:
                             except Exception:
                                 pass
                             stream_generator = None
-                        
+
                         if "context manager is already active" in str(exc):
                             if self.debug:
                                 from upsonic.utils.printing import debug_log
@@ -904,6 +923,11 @@ class Chat:
             
             try:
                 for attempt in range(self._retry_attempts + 1):
+                    if attempt > 0:
+                        # Reset task state so the next attempt is treated as a
+                        # fresh run (see _stream_with_retry for rationale).
+                        task.status = None
+                        task.run_id = None
                     try:
                         stream_generator = _execute_streaming_events()
                         async for event in stream_generator:

--- a/src/upsonic/messages/messages.py
+++ b/src/upsonic/messages/messages.py
@@ -1278,7 +1278,14 @@ class BaseToolCallPart:
             return {}
         if isinstance(self.args, dict):
             return self.args
-        args = pydantic_core.from_json(self.args)
+        try:
+            args = pydantic_core.from_json(self.args)
+        except ValueError:
+            # Some providers (e.g. Gemma via OpenRouter with harmony-format
+            # output) append non-JSON trailing tokens after the valid args
+            # object. Recover the leading JSON object and discard the rest.
+            import json as _json
+            args, _ = _json.JSONDecoder().raw_decode(self.args)
         assert isinstance(args, dict), 'args should be a dict'
         return cast(dict[str, Any], args)
 


### PR DESCRIPTION
…k on retry (#597)

- ToolCallPart.args_as_dict() now falls back to JSONDecoder.raw_decode when pydantic_core.from_json sees trailing characters, so providers that append harmony-format tokens after the JSON args (e.g. Gemma 4 via OpenRouter) no longer crash the streaming pipeline.

- Chat retry paths (_invoke_blocking_async, _stream_with_retry, _stream_events_with_retry) now reset task.status/run_id before each retry attempt, mirroring do_async's internal behavior. Previously the previous attempt's mark_completed leaked onto the task and the next attempt tripped _validate_task_for_new_run with "Task is already completed", silently swallowing the retry.