### PR TITLE
fix(pipeline): preserve error state on streaming failure TECH-1635

### DIFF
--- a/src/upsonic/agent/pipeline/manager.py
+++ b/src/upsonic/agent/pipeline/manager.py
@@ -679,17 +679,39 @@ class PipelineManager:
                 context.tool_limit_reached = getattr(self.agent, '_tool_limit_reached', False)
             
             if self.debug:
-                from upsonic.utils.printing import pipeline_failed
+                from upsonic.utils.printing import pipeline_failed, debug_log_level2
+                import traceback as _traceback
+                # Pull the actual failing step from context (Sorun 3 + 4) so
+                # the panel shows "Failed Step: <name>" instead of "Unknown".
+                failed_step_result = context.get_error_step() or context.current_step_result
+                err_text = str(e) if str(e) else type(e).__name__
                 pipeline_failed(
-                    str(e),
+                    err_text,
                     context.execution_stats.executed_steps if context.execution_stats else 0,
                     context.execution_stats.total_steps if context.execution_stats else len(self.steps),
-                    None,
-                    None
+                    failed_step_result.name if failed_step_result else None,
+                    failed_step_result.execution_time if failed_step_result else None,
                 )
-            
+
+                debug_level = getattr(self.agent, 'debug_level', 1) if self.agent else 1
+                if debug_level >= 2:
+                    error_traceback = ''.join(_traceback.format_exception(type(e), e, e.__traceback__))
+                    debug_log_level2(
+                        "Streaming pipeline execution error",
+                        "PipelineManager",
+                        debug=self.debug,
+                        debug_level=debug_level,
+                        error_type=type(e).__name__,
+                        error_message=str(e),
+                        error_traceback=error_traceback[-2000:],
+                        failed_step_index=failed_step_result.step_number if failed_step_result else 0,
+                        failed_step_name=failed_step_result.name if failed_step_result else "Unknown",
+                        executed_steps=context.execution_stats.executed_steps if context.execution_stats else 0,
+                        total_steps=context.execution_stats.total_steps if context.execution_stats else len(self.steps),
+                    )
+
             raise
-        
+
           finally:
             total_time = time.time() - pipeline_start_time
             executed_steps = context.execution_stats.executed_steps if context.execution_stats else 0
@@ -704,7 +726,15 @@ class PipelineManager:
                     error_message=error_message
                 )
 
-                if context.step_results and context.step_results[-1].status == StepStatus.COMPLETED:
+                # Only finalize as completed when the pipeline actually
+                # succeeded. ``error_message`` is set in the except branch;
+                # without this gate the failing path also calls
+                # ``mark_completed()`` and overwrites ``mark_error()``.
+                if (
+                    error_message is None
+                    and context.step_results
+                    and context.step_results[-1].status == StepStatus.COMPLETED
+                ):
                     if self.agent and self.agent._agent_run_output:
                         self.agent._agent_run_output.mark_completed()
                         context.tool_call_count = getattr(self.agent, '_tool_call_count', 0)

--- a/src/upsonic/agent/pipeline/step.py
+++ b/src/upsonic/agent/pipeline/step.py
@@ -292,25 +292,28 @@ class Step(ABC):
         
         # Initialize result holder in context
         context.current_step_result = None
-        
-        # Execute step - consume generator and yield all events
-        async for event in self.execute_stream(context, task, agent, model, step_number, pipeline_manager=pipeline_manager):
-            yield event
-        
-        # Get result from context (set by execute_stream())
-        result = context.current_step_result
-        
-        # Finalize step result (updates context.step_results and execution_stats)
-        if result:
-            self._finalize_step_result(result, context)
-        
-        # Yield step end event
-        if result:
-            yield StepEndEvent(
-                run_id=run_id,
-                step_name=self.name,
-                step_index=step_number,
-                status=result.status.value,
-                execution_time=result.execution_time,
-                message=result.message or ""
-            )
+
+        try:
+            # Execute step - consume generator and yield all events
+            async for event in self.execute_stream(context, task, agent, model, step_number, pipeline_manager=pipeline_manager):
+                yield event
+        finally:
+            # Even on exception, finalize the step result so step_results
+            # reflects the failing step (status=ERROR/CANCELLED). Without
+            # this, PipelineManager.execute_stream sees step_results[-1]
+            # as the previous successful step and erroneously marks the
+            # run as completed in its finally branch.
+            result = context.current_step_result
+            if result:
+                self._finalize_step_result(result, context)
+                try:
+                    yield StepEndEvent(
+                        run_id=run_id,
+                        step_name=self.name,
+                        step_index=step_number,
+                        status=result.status.value,
+                        execution_time=result.execution_time,
+                        message=result.message or ""
+                    )
+                except GeneratorExit:
+                    pass

--- a/src/upsonic/agent/pipeline/steps.py
+++ b/src/upsonic/agent/pipeline/steps.py
@@ -3053,15 +3053,19 @@ class StreamModelExecutionStep(Step):
             
             context.output = cached_content
             context.current_step_result = StepResult(
+                name=self.name,
+                step_number=step_number,
                 status=StepStatus.SKIPPED,
                 message="Skipped due to cache hit",
                 execution_time=time.time() - start_time
             )
             return
-        
+
         if task._policy_blocked:
             yield FinalOutputEvent(run_id=run_id, output=None, output_type='blocked')
             context.current_step_result = StepResult(
+                name=self.name,
+                step_number=step_number,
                 status=StepStatus.SKIPPED,
                 message="Skipped due to policy block",
                 execution_time=time.time() - start_time
@@ -3123,12 +3127,14 @@ class StreamModelExecutionStep(Step):
             # Check if execution was paused (streaming does not support HITL resumption)
             if task.is_paused:
                 context.current_step_result = StepResult(
+                    name=self.name,
+                    step_number=step_number,
                     status=StepStatus.PAUSED,
                     message="Execution paused (use direct call mode for HITL continuation)",
                     execution_time=time.time() - start_time
                 )
                 return
-            
+
             # Extract output and update context
             output = agent._extract_output(task, context.response)
 
@@ -3142,26 +3148,36 @@ class StreamModelExecutionStep(Step):
                 output_type='structured' if not isinstance(output, str) else 'text'
             )
             # Note: Message finalization is deferred to StreamMemoryMessageTrackingStep
-            # This ensures all steps (including AgentPolicyStep feedback loop) 
+            # This ensures all steps (including AgentPolicyStep feedback loop)
             # can add their messages to chat_history before we extract new messages
-            
+
             context.current_step_result = StepResult(
+                name=self.name,
+                step_number=step_number,
                 status=StepStatus.COMPLETED,
                 message="Streaming execution completed",
                 execution_time=time.time() - start_time
             )
-            
+
         except asyncio.CancelledError:
             context.current_step_result = StepResult(
+                name=self.name,
+                step_number=step_number,
                 status=StepStatus.CANCELLED,
                 message="Cancelled due to timeout",
                 execution_time=time.time() - start_time
             )
             raise
         except Exception as e:
+            # Prefix exception type so empty SDK messages still produce a
+            # readable panel/log entry (some Anthropic streaming errors
+            # come with message="" — Sorun 5).
+            err_text = str(e) or type(e).__name__
             context.current_step_result = StepResult(
+                name=self.name,
+                step_number=step_number,
                 status=StepStatus.ERROR,
-                message=f"Streaming execution failed: {str(e)}",
+                message=f"Streaming execution failed: {err_text}",
                 execution_time=time.time() - start_time
             )
             raise

--- a/src/upsonic/chat/chat.py
+++ b/src/upsonic/chat/chat.py
@@ -355,16 +355,31 @@ class Chat:
         """Clear the chat history from storage (async)."""
         await self._session_manager.aclear_history()
     
+    def _clear_usage_entries(self) -> None:
+        """Drop every usage-registry entry tagged with this chat's
+        ``chat_usage_id`` so ``chat.usage.cost`` etc. reset to zero.
+        Uses the registry's existing ``entries`` filter + ``remove`` so
+        no chat-specific helper is needed on the registry side.
+        """
+        from upsonic.usage_registry import get_default_registry
+        registry = get_default_registry()
+        for entry in registry.entries(chat_usage_id=self.chat_usage_id):
+            registry.remove(entry.entry_id)
+
     def reset_session(self) -> None:
         """
         Reset the chat session to initial state.
-        
-        This deletes the session from storage and resets runtime state.
+
+        This deletes the session from storage, drops the cached usage
+        entries (so ``chat.usage.cost`` etc. reset to zero), and resets
+        runtime state.
         """
+        self._clear_usage_entries()
         self._session_manager.reset_session()
-    
+
     async def areset_session(self) -> None:
         """Reset the chat session to initial state (async)."""
+        self._clear_usage_entries()
         await self._session_manager.areset_session()
     
     def reopen(self) -> None:

--- a/src/upsonic/models/anthropic.py
+++ b/src/upsonic/models/anthropic.py
@@ -458,11 +458,21 @@ class AnthropicModel(Model):
                 extra_body=model_settings.get('extra_body'),
             )
         except APIStatusError as e:
+            # Anthropic SDK occasionally exposes an empty ``e.message``;
+            # fall back to ``repr(e)`` / type name so panels and Sentry
+            # entries are not "(no message)".
+            msg = e.message or repr(e) or type(e).__name__
             if (status_code := e.status_code) >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise ModelAPIError(model_name=self.model_name, message=e.message) from e  # pragma: lax no cover
+                raise ModelHTTPError(
+                    status_code=status_code,
+                    model_name=self.model_name,
+                    body=e.body,
+                    message=msg,
+                ) from e
+            raise ModelAPIError(model_name=self.model_name, message=msg) from e  # pragma: lax no cover
         except APIConnectionError as e:
-            raise ModelAPIError(model_name=self.model_name, message=e.message) from e
+            msg = e.message or repr(e) or type(e).__name__
+            raise ModelAPIError(model_name=self.model_name, message=msg) from e
 
     def _get_betas_and_extra_headers(
         self,
@@ -541,11 +551,18 @@ class AnthropicModel(Model):
                 extra_body=model_settings.get('extra_body'),
             )
         except APIStatusError as e:
+            msg = e.message or repr(e) or type(e).__name__
             if (status_code := e.status_code) >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise ModelAPIError(model_name=self.model_name, message=e.message) from e  # pragma: lax no cover
+                raise ModelHTTPError(
+                    status_code=status_code,
+                    model_name=self.model_name,
+                    body=e.body,
+                    message=msg,
+                ) from e
+            raise ModelAPIError(model_name=self.model_name, message=msg) from e  # pragma: lax no cover
         except APIConnectionError as e:
-            raise ModelAPIError(model_name=self.model_name, message=e.message) from e
+            msg = e.message or repr(e) or type(e).__name__
+            raise ModelAPIError(model_name=self.model_name, message=msg) from e
 
     def _process_response(self, response: BetaMessage) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""

--- a/src/upsonic/utils/package/exception.py
+++ b/src/upsonic/utils/package/exception.py
@@ -227,12 +227,25 @@ class ModelHTTPError(AgentRunError):
     message: str
     """The error message with the status code and response body, if available."""
 
-    def __init__(self, status_code: int, model_name: str, body: object | None = None):
+    def __init__(
+        self,
+        status_code: int,
+        model_name: str,
+        body: object | None = None,
+        message: str | None = None,
+    ):
         self.status_code = status_code
         self.model_name = model_name
         self.body = body
-        message = f'status_code: {status_code}, model_name: {model_name}, body: {body}'
-        super().__init__(message)
+        # Allow callers to override the default message string so that
+        # provider SDKs can attach a richer description (e.g. when the
+        # upstream `e.message` is empty, fall back to repr/type name).
+        self.message = (
+            message
+            if message
+            else f'status_code: {status_code}, model_name: {model_name}, body: {body}'
+        )
+        super().__init__(self.message)
 
 class ModelAPIError(AgentRunError):
     """Raised when a model provider API request fails."""

--- a/src/upsonic/utils/printing.py
+++ b/src/upsonic/utils/printing.py
@@ -2425,7 +2425,8 @@ def pipeline_failed(error_message: str, executed_steps: int, total_steps: int, f
         failed_step: Name of the step that failed
         step_time: Time taken by the failed step
     """
-    error_esc = escape_rich_markup(error_message)
+    safe_error = error_message if error_message else "(no message — see traceback)"
+    error_esc = escape_rich_markup(safe_error)
     failed_step_esc = escape_rich_markup(failed_step) if failed_step else "Unknown"
 
     table = Table(show_header=False, expand=True, box=None)

--- a/tests/smoke_tests/chat/test_chat.py
+++ b/tests/smoke_tests/chat/test_chat.py
@@ -49,7 +49,7 @@ def test_chat_reuses_agent_memory_and_storage():
     # Build Memory with matching ids so no alignment warning is triggered.
     agent_memory = Memory(storage=shared, session_id="reuse-default", user_id="u")
     agent = Agent(
-        model="openai/gpt-4o-mini",
+        model="anthropic/claude-haiku-4-5",
         name="Storage Reuse Agent",
         memory=agent_memory,
     )
@@ -66,7 +66,7 @@ def test_chat_reuses_agent_memory_and_storage():
 
 def test_chat_creates_storage_when_agent_has_none():
     """No memory on the agent ⇒ Chat creates one and wires it into the agent."""
-    agent = Agent(model="openai/gpt-4o-mini", name="Storage Reuse Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Storage Reuse Agent")
     assert agent.memory is None
 
     chat = Chat(session_id="reuse-fresh", user_id="u", agent=agent)
@@ -81,7 +81,7 @@ def test_chat_creates_storage_when_agent_has_none():
 def test_chat_explicit_storage_used_only_when_agent_has_no_memory():
     """No agent memory + explicit Chat storage ⇒ Chat's storage is used."""
     chat_storage = InMemoryStorage()
-    agent = Agent(model="openai/gpt-4o-mini", name="Storage Reuse Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Storage Reuse Agent")
     assert agent.memory is None
 
     chat = Chat(
@@ -104,7 +104,7 @@ def test_agent_storage_wins_over_chat_explicit_storage():
     agent_storage = InMemoryStorage()
     agent_memory = Memory(storage=agent_storage, session_id="agent-wins", user_id="u")
     agent = Agent(
-        model="openai/gpt-4o-mini",
+        model="anthropic/claude-haiku-4-5",
         name="Storage Reuse Agent",
         memory=agent_memory,
     )
@@ -133,7 +133,7 @@ def test_chat_aligns_session_id_with_agent_memory():
         user_id="u",
     )
     agent = Agent(
-        model="openai/gpt-4o-mini",
+        model="anthropic/claude-haiku-4-5",
         name="Align Agent",
         memory=agent_memory,
     )
@@ -158,7 +158,7 @@ def test_chat_aligns_user_id_with_agent_memory():
         user_id="agent-user",
     )
     agent = Agent(
-        model="openai/gpt-4o-mini",
+        model="anthropic/claude-haiku-4-5",
         name="Align Agent",
         memory=agent_memory,
     )
@@ -180,7 +180,7 @@ def test_chat_no_warning_when_ids_match_agent_memory():
         user_id="u-match",
     )
     agent = Agent(
-        model="openai/gpt-4o-mini",
+        model="anthropic/claude-haiku-4-5",
         name="Match Agent",
         memory=agent_memory,
     )
@@ -200,7 +200,7 @@ async def test_chat_basic_invoke():
     print("TEST: test_chat_basic_invoke")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_1",
         user_id="test_user_1",
@@ -261,7 +261,7 @@ async def test_chat_streaming():
     print("TEST: test_chat_streaming")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_2",
         user_id="test_user_2",
@@ -314,7 +314,7 @@ async def test_chat_conversation_history():
     print("TEST: test_chat_conversation_history")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_3",
         user_id="test_user_3",
@@ -375,7 +375,7 @@ async def test_chat_all_attributes():
     print("TEST: test_chat_all_attributes")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_4",
         user_id="test_user_4",
@@ -496,7 +496,7 @@ async def test_chat_with_task():
     print("TEST: test_chat_with_task")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_5",
         user_id="test_user_5",
@@ -531,7 +531,7 @@ async def test_chat_cost_tracking():
     print("TEST: test_chat_cost_tracking")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_6",
         user_id="test_user_6",
@@ -613,7 +613,7 @@ async def test_chat_clear_history():
     print("TEST: test_chat_clear_history")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_7",
         user_id="test_user_7",
@@ -664,7 +664,7 @@ async def test_chat_reset_session():
     print("TEST: test_chat_reset_session")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_8",
         user_id="test_user_8",
@@ -716,7 +716,7 @@ async def test_chat_state_transitions():
     print("TEST: test_chat_state_transitions")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_9",
         user_id="test_user_9",
@@ -749,7 +749,7 @@ async def test_chat_message_content_types():
     print("TEST: test_chat_message_content_types")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_10",
         user_id="test_user_10",
@@ -798,7 +798,7 @@ async def test_chat_async_context_manager():
     print("TEST: test_chat_async_context_manager")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     
     async with Chat(
         session_id="test_session_11",
@@ -827,7 +827,7 @@ async def test_chat_repr():
     print("TEST: test_chat_repr")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_12",
         user_id="test_user_12",
@@ -861,7 +861,7 @@ async def test_chat_message_index():
     print("TEST: test_chat_message_index")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_13",
         user_id="test_user_13",
@@ -898,7 +898,7 @@ async def test_chat_delete_message():
     print("TEST: test_chat_delete_message")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_14",
         user_id="test_user_14",
@@ -953,7 +953,7 @@ async def test_chat_get_set_raw_messages():
     print("TEST: test_chat_get_set_raw_messages")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_15",
         user_id="test_user_15",
@@ -1008,7 +1008,7 @@ async def test_chat_with_attachments():
     print(f"  - PDF: {pdf_path}")
     print(f"  - Image: {image_path}")
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_16",
         user_id="test_user_16",
@@ -1167,7 +1167,7 @@ async def test_chat_history_manipulation_workflow():
     print("TEST: test_chat_history_manipulation_workflow")
     print("="*60)
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_17",
         user_id="test_user_17",
@@ -1238,7 +1238,7 @@ async def test_chat_remove_attachment():
     assert os.path.exists(pdf_path), f"PDF file not found: {pdf_path}"
     assert os.path.exists(image_path), f"Image file not found: {image_path}"
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_remove_att",
         user_id="test_user_remove_att",
@@ -1356,7 +1356,7 @@ async def test_chat_session_timing():
     
     import time
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_timing",
         user_id="test_user_timing",
@@ -1460,7 +1460,7 @@ async def test_chat_remove_attachment_by_path():
     assert os.path.exists(pdf_path), f"PDF file not found: {pdf_path}"
     assert os.path.exists(image_path), f"Image file not found: {image_path}"
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_remove_by_path",
         user_id="test_user_remove_by_path",
@@ -1563,7 +1563,7 @@ async def test_chat_reopen_session():
     
     import time
     
-    agent = Agent(model="openai/gpt-4o", name="Chat Agent")
+    agent = Agent(model="anthropic/claude-haiku-4-5", name="Chat Agent")
     chat = Chat(
         session_id="test_session_reopen",
         user_id="test_user_reopen",

--- a/tests/smoke_tests/chat/test_chat_event_streaming.py
+++ b/tests/smoke_tests/chat/test_chat_event_streaming.py
@@ -51,7 +51,7 @@ async def test_chat_stream_events_basic():
     print("TEST: test_chat_stream_events_basic")
     print("=" * 60)
     
-    agent = Agent(model="openai/gpt-4o", tools=[add_numbers])
+    agent = Agent(model="anthropic/claude-haiku-4-5", tools=[add_numbers])
     chat = Chat(
         session_id="test_event_stream_1",
         user_id="test_user",
@@ -121,7 +121,7 @@ async def test_chat_invoke_stream_events():
     print("TEST: test_chat_invoke_stream_events")
     print("=" * 60)
     
-    agent = Agent(model="openai/gpt-4o", tools=[multiply_numbers])
+    agent = Agent(model="anthropic/claude-haiku-4-5", tools=[multiply_numbers])
     chat = Chat(
         session_id="test_event_stream_2",
         user_id="test_user",
@@ -163,7 +163,7 @@ async def test_chat_stream_events_no_tools():
     print("=" * 60)
     
     # Agent without tools
-    agent = Agent(model="openai/gpt-4o")
+    agent = Agent(model="anthropic/claude-haiku-4-5")
     chat = Chat(
         session_id="test_event_stream_3",
         user_id="test_user",
@@ -205,7 +205,7 @@ async def test_chat_stream_tool_result_content():
     print("TEST: test_chat_stream_tool_result_content")
     print("=" * 60)
     
-    agent = Agent(model="openai/gpt-4o", tools=[add_numbers])
+    agent = Agent(model="anthropic/claude-haiku-4-5", tools=[add_numbers])
     chat = Chat(
         session_id="test_event_stream_4",
         user_id="test_user",
@@ -253,7 +253,7 @@ async def test_chat_stream_multiple_messages():
     print("TEST: test_chat_stream_multiple_messages")
     print("=" * 60)
     
-    agent = Agent(model="openai/gpt-4o", tools=[add_numbers])
+    agent = Agent(model="anthropic/claude-haiku-4-5", tools=[add_numbers])
     chat = Chat(
         session_id="test_event_stream_5",
         user_id="test_user",
@@ -299,7 +299,7 @@ async def test_chat_stream_events_with_context():
     print("TEST: test_chat_stream_events_with_context")
     print("=" * 60)
     
-    agent = Agent(model="openai/gpt-4o")
+    agent = Agent(model="anthropic/claude-haiku-4-5")
     chat = Chat(
         session_id="test_event_stream_6",
         user_id="test_user",

--- a/tests/smoke_tests/chat/test_chat_retry.py
+++ b/tests/smoke_tests/chat/test_chat_retry.py
@@ -37,7 +37,7 @@ from tests._pipeline_injection import (
 
 pytestmark = pytest.mark.timeout(300)
 
-MODEL = "openai/gpt-4o-mini"
+MODEL = "anthropic/claude-haiku-4-5"
 
 COMPLETED_WARNING_FRAGMENT = "Task is already completed"
 

--- a/tests/smoke_tests/chat/test_chat_streaming_failure.py
+++ b/tests/smoke_tests/chat/test_chat_streaming_failure.py
@@ -1,0 +1,282 @@
+"""
+Chat Streaming Failure Smoke Tests
+
+End-to-end regression for the streaming pipeline's mid-stream failure
+path. Mirrors the autonomous-HQ chat.py screenshot symptom:
+
+Before the fix, when ``StreamModelExecutionStep`` raised mid-stream,
+``PipelineManager.execute_stream``'s ``finally`` block called
+``mark_completed()`` after the ``except`` had already called
+``mark_error()`` — because the failing step was never appended to
+``context.step_results``. The task ended up with ``status=completed``
+even though the run failed. Any subsequent call passing the SAME
+``Task`` instance to ``Agent.astream`` / ``Agent.do_async`` then
+tripped ``_validate_task_for_new_run``'s completed-task guard with:
+  ``[Agent] Task is already completed (run_id=…). Cannot re-run a completed task.``
+
+After the fix the task stays in ``RunStatus.error`` and the
+completed-guard never fires.
+
+This file uses a deterministic ``Model`` subclass instead of a real
+provider so the streaming exception path is exercised reliably without
+network flakiness. ``inject_error_into_step`` is deliberately NOT used
+here: it patches ``Step.run`` (non-streaming) and HITL is not
+supported in streaming yet.
+
+Scenarios:
+  1. Single streaming invoke fails → task ends up in ``RunStatus.error``,
+     not ``RunStatus.completed``.
+  2. Failing step's ``StepResult`` is appended to ``step_results`` so
+     observability tooling (``pipeline_failed`` panel, sentry log, the
+     ``get_error_step`` API) can identify the failure point.
+  3. Re-using the failed ``Task`` instance MUST NOT trigger the
+     completed-task guard's "Task is already completed" warning.
+
+Run with: ``uv run pytest tests/smoke_tests/chat/test_chat_streaming_failure.py -v -s``
+"""
+
+import logging
+import time
+from contextlib import asynccontextmanager
+
+import pytest
+
+from upsonic import Agent, Chat
+from upsonic.messages.messages import ModelResponse, TextPart
+from upsonic.models import Model
+from upsonic.run.base import RunStatus
+from upsonic.usage import RequestUsage
+
+
+pytestmark = pytest.mark.timeout(120)
+
+COMPLETED_WARNING_FRAGMENT = "Task is already completed"
+
+
+class _MidStreamFailModel(Model):
+    """Deterministic streaming failure model.
+
+    ``request`` succeeds (so non-streaming preflight steps like
+    ``LLMManager``, ``ModelSelection``, ``MessageAssembly`` complete
+    without issue) and ``request_stream`` raises inside ``__anext__``
+    — landing the failure inside ``StreamModelExecutionStep``.
+    """
+
+    @property
+    def model_name(self) -> str:
+        return "smoke-fail-model"
+
+    @property
+    def system(self) -> str:
+        return "smoke-test-provider"
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        return ModelResponse(
+            parts=[TextPart(content="ok")],
+            model_name=self.model_name,
+            timestamp=time.time(),
+            usage=RequestUsage(input_tokens=1, output_tokens=1, details={}),
+            provider_name="smoke-test-provider",
+            provider_response_id="id",
+            provider_details={},
+            finish_reason="stop",
+        )
+
+    @asynccontextmanager
+    async def request_stream(self, messages, model_settings, model_request_parameters):
+        class _FailingIter:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, exc_type, exc_val, exc_tb):
+                pass
+
+            def __aiter__(self_inner):
+                return self_inner
+
+            async def __anext__(self_inner):
+                # Empty-message exception mirrors the original Anthropic
+                # streaming failure shape from the autonomous-HQ screenshot.
+                raise Exception("")
+
+        yield _FailingIter()
+
+
+class _UpsonicLogCapture:
+    """Capture WARNING-level records emitted to the ``upsonic`` logger.
+
+    ``warning_log`` in ``src/upsonic/utils/printing.py`` writes both to
+    a Rich console (captured by ``capsys``) AND to the ``upsonic.user``
+    Python logger (NOT captured by ``capsys``). We install a temporary
+    list-handler to catch the latter.
+    """
+
+    def __init__(self):
+        self.records: list[logging.LogRecord] = []
+        self._handler: logging.Handler | None = None
+        self._logger: logging.Logger | None = None
+        self._prev_level: int | None = None
+
+    def __enter__(self):
+        self._logger = logging.getLogger("upsonic")
+        self._prev_level = self._logger.level
+        self._logger.setLevel(logging.WARNING)
+        store = self.records
+
+        class _ListHandler(logging.Handler):
+            def __init__(self):
+                super().__init__(level=logging.WARNING)
+
+            def emit(self, record: logging.LogRecord) -> None:
+                store.append(record)
+
+        self._handler = _ListHandler()
+        self._logger.addHandler(self._handler)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._logger is not None and self._handler is not None:
+            self._logger.removeHandler(self._handler)
+        if self._logger is not None and self._prev_level is not None:
+            self._logger.setLevel(self._prev_level)
+
+    def has_message_containing(self, fragment: str) -> bool:
+        return any(fragment in record.getMessage() for record in self.records)
+
+
+def _build_chat(session_suffix: str) -> tuple[Chat, Agent]:
+    agent = Agent(model=_MidStreamFailModel(), name="SmokeStreamFailAgent")
+    chat = Chat(
+        session_id=f"smoke-stream-fail-{session_suffix}",
+        user_id="smoke-user",
+        agent=agent,
+    )
+    return chat, agent
+
+
+# ---------------------------------------------------------------------------
+# 1. Task ends up in RunStatus.error, not RunStatus.completed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_streaming_failure_leaves_run_in_error_state():
+    """After a mid-stream failure the run must be marked as ``error``.
+    A run incorrectly marked as ``completed`` would cause the next
+    invoke to bypass any continue-run logic and silently misbehave.
+    """
+    chat, agent = _build_chat("state")
+
+    try:
+        with pytest.raises(Exception):
+            stream = await chat.invoke("trigger failure", stream=True, events=True)
+            async for _ in stream:
+                pass
+
+        out = agent.get_run_output()
+        assert out is not None, "Agent must have a run output after invoke"
+        assert out.status == RunStatus.error, (
+            f"Expected RunStatus.error after streaming failure, got {out.status}. "
+            f"The pipeline finally block is overwriting mark_error() with "
+            f"mark_completed()."
+        )
+    finally:
+        await chat.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Failing step is appended to step_results (observability)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_streaming_failure_records_failing_step_in_step_results():
+    """``step_results[-1]`` must reflect the failing step's ERROR status
+    (not the previous successful step's COMPLETED status). This is
+    what ``get_error_step()`` and the ``pipeline_failed`` panel rely on.
+    """
+    from upsonic.agent.pipeline.step import StepStatus
+
+    chat, agent = _build_chat("observability")
+
+    try:
+        with pytest.raises(Exception):
+            stream = await chat.invoke("trigger failure", stream=True, events=True)
+            async for _ in stream:
+                pass
+
+        out = agent.get_run_output()
+        assert out is not None
+        assert out.step_results, (
+            "step_results must not be empty after a failed streaming run"
+        )
+        last_step = out.step_results[-1]
+        assert last_step.status in (StepStatus.ERROR, StepStatus.CANCELLED), (
+            f"Last recorded step must be ERROR/CANCELLED, got {last_step.status}. "
+            f"Step.run_stream is not finalizing the failing step into step_results."
+        )
+        assert last_step.name, (
+            f"Failing StepResult must carry a name (got {last_step.name!r}). "
+            f"StreamModelExecutionStep's exception branch is constructing "
+            f"StepResult without name/step_number."
+        )
+    finally:
+        await chat.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Re-using the failed Task instance does NOT trip the completed-guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reused_failed_task_does_not_trip_completed_guard():
+    """Direct end-to-end regression for the autonomous-HQ screenshot.
+
+    Passing the SAME ``Task`` instance back through ``chat.invoke``
+    must NOT emit the ``Task is already completed`` warning. It is OK
+    for the framework to refuse with the *problematic-run* warning
+    (``status=ERROR``) — but the ``is_completed`` branch must never
+    fire on a task that actually failed.
+    """
+    chat, _ = _build_chat("reuse")
+
+    # Hook ``_normalize_input`` so we can capture the Task object Chat
+    # creates on the first (string) invoke and re-feed it on the second.
+    captured_tasks: list = []
+    original_normalize = chat._normalize_input
+
+    def _capture(input_data, context=None):
+        t = original_normalize(input_data, context)
+        captured_tasks.append(t)
+        return t
+
+    chat._normalize_input = _capture
+
+    try:
+        with _UpsonicLogCapture() as logs:
+            # 1st invoke (string) — fresh Task, fails mid-stream.
+            with pytest.raises(Exception):
+                stream = await chat.invoke("first", stream=True, events=True)
+                async for _ in stream:
+                    pass
+
+            assert captured_tasks, "Chat must materialize a Task on first invoke"
+            failed_task = captured_tasks[0]
+
+            # 2nd invoke with the SAME Task instance — the validate call
+            # runs again against a task whose status is now error/completed.
+            try:
+                stream = await chat.invoke(failed_task, stream=True, events=True)
+                async for _ in stream:
+                    pass
+            except Exception:
+                pass
+
+        # Hard regression assertion.
+        assert not logs.has_message_containing(COMPLETED_WARNING_FRAGMENT), (
+            f"Regression: re-using a failed Task fired the completed-task "
+            f"guard ('Task is already completed'). Pipeline finally is "
+            f"overwriting mark_error() with mark_completed().\n"
+            f"Captured warnings: "
+            f"{[r.getMessage() for r in logs.records]}"
+        )
+    finally:
+        await chat.close()

--- a/tests/unit_tests/chat/test_chat.py
+++ b/tests/unit_tests/chat/test_chat.py
@@ -481,6 +481,161 @@ class TestChatHistoryMethods:
         """Test that remove_attachment method exists."""
         agent = MockAgent()
         chat = Chat(session_id="test", user_id="user", agent=agent)
-        
+
         assert hasattr(chat, 'remove_attachment')
         assert callable(chat.remove_attachment)
+
+
+class TestChatStreamingErrorState:
+    """End-to-end regression for the ``Chat`` → ``Agent.astream`` →
+    ``PipelineManager`` mid-stream-failure path. Mirrors the autonomous-HQ
+    chat.py screenshot.
+
+    Chat's ``_stream_events_with_retry`` retries the SAME task on
+    exception (default ``retry_attempts=3``). Before the fix, the
+    pipeline's ``finally`` block ran ``mark_completed()`` after
+    ``mark_error()`` because the failing step was never appended to
+    ``step_results`` — so on attempt 2, ``_validate_task_for_new_run``
+    saw ``task.is_completed=True`` and emitted
+    "Task is already completed (run_id=…). Cannot re-run a completed task."
+    After the fix the task stays in ``RunStatus.error`` and the
+    completed-guard never trips.
+    """
+
+    @staticmethod
+    def _build_chat_with_failing_stream(session_suffix: str):
+        """Real ``Agent`` with a ``MockModel`` whose ``request_stream``
+        raises inside __anext__ (so non-streaming preflight steps pass
+        and the failure lands in StreamModelExecutionStep).
+        Each test must pass a unique ``session_suffix`` so storage state
+        does not bleed across tests.
+        """
+        from contextlib import asynccontextmanager
+        import time as _time
+        from upsonic import Agent
+        from upsonic.models import Model
+        from upsonic.messages.messages import ModelResponse, TextPart
+        from upsonic.usage import RequestUsage
+
+        class _MockModel(Model):
+            def __init__(self):
+                super().__init__()
+
+            @property
+            def model_name(self):
+                return "test-model"
+
+            @property
+            def system(self):
+                return "test-provider"
+
+            async def request(self, messages, model_settings, model_request_parameters):
+                return ModelResponse(
+                    parts=[TextPart(content="ok")],
+                    model_name="test-model",
+                    timestamp=_time.time(),
+                    usage=RequestUsage(input_tokens=1, output_tokens=1, details={}),
+                    provider_name="test-provider",
+                    provider_response_id="id",
+                    provider_details={},
+                    finish_reason="stop",
+                )
+
+            @asynccontextmanager
+            async def request_stream(self, messages, model_settings, model_request_parameters):
+                class _Iter:
+                    async def __aenter__(self_inner):
+                        return self_inner
+
+                    async def __aexit__(self_inner, exc_type, exc_val, exc_tb):
+                        pass
+
+                    def __aiter__(self_inner):
+                        return self_inner
+
+                    async def __anext__(self_inner):
+                        raise Exception("Stream error mid-flight")
+
+                yield _Iter()
+
+        agent = Agent(model=_MockModel(), name="StreamFailAgent")
+        chat = Chat(
+            session_id=f"test-stream-fail-{session_suffix}",
+            user_id="test-user",
+            agent=agent,
+        )
+        return chat, agent
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_failure_leaves_task_in_error_state(self):
+        """After ``chat.invoke(stream=True)`` raises mid-flight, the
+        underlying run must be ``RunStatus.error`` — NOT
+        ``RunStatus.completed``. Without the fix, the pipeline finally
+        block overrides ``mark_error()`` with ``mark_completed()``.
+        """
+        from upsonic.run.base import RunStatus
+
+        chat, agent = self._build_chat_with_failing_stream("status")
+
+        with pytest.raises(Exception):
+            stream = await chat.invoke("hello", stream=True, events=True)
+            async for _ in stream:
+                pass
+
+        out = agent.get_run_output()
+        assert out is not None
+        assert out.status == RunStatus.error, (
+            f"AgentRunOutput.status must be error after a failed stream, "
+            f"got {out.status}. The pipeline finally block is overwriting "
+            f"mark_error() with mark_completed()."
+        )
+
+    @pytest.mark.asyncio
+    async def test_reused_task_after_stream_failure_does_not_trip_completed_guard(self, capsys):
+        """Direct regression for the autonomous-HQ symptom.
+
+        After a failed streaming invoke, passing the SAME ``Task`` instance
+        back through ``chat.invoke(task_obj)`` must NOT emit:
+        "Task is already completed (run_id=…). Cannot re-run a completed task."
+
+        It is acceptable for the framework to refuse with the
+        ``problematic run`` message (status=ERROR) — but the
+        ``is_completed`` branch must never fire on a failed task.
+        """
+        chat, _ = self._build_chat_with_failing_stream("reuse")
+
+        # 1st invoke (string) — fresh Task, fails mid-stream.
+        task_holder: list = []
+        # Hook _normalize_input to capture the Task object created by Chat.
+        original_normalize = chat._normalize_input
+
+        def _capture(input_data, context=None):
+            t = original_normalize(input_data, context)
+            task_holder.append(t)
+            return t
+
+        chat._normalize_input = _capture
+
+        with pytest.raises(Exception):
+            stream = await chat.invoke("hello", stream=True, events=True)
+            async for _ in stream:
+                pass
+
+        assert task_holder, "Expected Chat to materialize a Task on first invoke"
+        failed_task = task_holder[0]
+
+        # 2nd invoke (same Task instance) — guard runs again.
+        try:
+            stream = await chat.invoke(failed_task, stream=True, events=True)
+            async for _ in stream:
+                pass
+        except Exception:
+            pass
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Task is already completed" not in combined, (
+            "Regression: re-using a failed Task tripped the completed-task "
+            "guard. The pipeline finally branch is overwriting mark_error() "
+            "with mark_completed(). Output tail:\n" + combined[-800:]
+        )

--- a/tests/unit_tests/test_agent_streaming.py
+++ b/tests/unit_tests/test_agent_streaming.py
@@ -604,5 +604,154 @@ class TestAgentStreamingIntegration:
         assert len(results) == 3
 
 
+class TestStreamingErrorState:
+    """Regression suite for the streaming exception-path bug where
+    ``PipelineManager.execute_stream`` overwrote ``mark_error()`` with
+    ``mark_completed()`` in its ``finally`` block. The bug caused the
+    next invoke to fail validation with
+    "Task is already completed (run_id=…). Cannot re-run a completed task."
+    """
+
+    @pytest.fixture
+    def mock_model(self):
+        return MockModel()
+
+    @pytest.fixture
+    def agent(self, mock_model):
+        return Agent(model=mock_model, name="TestAgent")
+
+    @pytest.fixture
+    def simple_task(self):
+        return Task(description="Hello, world!")
+
+    @staticmethod
+    def _make_error_model():
+        """Real ``Model`` subclass; only ``request_stream`` fails (mid-stream)
+        so non-streaming preflight steps (LLMManager, ToolSetup, ...) succeed
+        and the failure lands inside ``StreamModelExecutionStep``.
+        """
+
+        class StreamErrorModel(MockModel):
+            @asynccontextmanager
+            async def request_stream(self, messages, model_settings, model_request_parameters):
+                class _Iter:
+                    async def __aenter__(self_inner):
+                        return self_inner
+
+                    async def __aexit__(self_inner, exc_type, exc_val, exc_tb):
+                        pass
+
+                    def __aiter__(self_inner):
+                        return self_inner
+
+                    async def __anext__(self_inner):
+                        # Fail mid-stream, not at __aenter__, so we are INSIDE
+                        # StreamModelExecutionStep.execute_stream when the
+                        # exception propagates.
+                        raise Exception("Stream error mid-flight")
+
+                yield _Iter()
+
+        return StreamErrorModel()
+
+    @pytest.mark.asyncio
+    async def test_streaming_error_leaves_task_status_as_error(self, agent, simple_task):
+        """task.status must be RunStatus.error (not completed) after a
+        mid-stream exception. If it gets marked completed, the next
+        ``_validate_task_for_new_run`` warns and refuses.
+        """
+        from upsonic.run.base import RunStatus
+
+        agent.model = self._make_error_model()
+
+        with pytest.raises(Exception):
+            async for _ in agent.astream(simple_task):
+                pass
+
+        assert simple_task.status == RunStatus.error, (
+            f"Expected task.status=RunStatus.error after stream failure, "
+            f"got {simple_task.status}. The pipeline finally block has "
+            f"overwritten mark_error() with mark_completed()."
+        )
+        assert simple_task.is_completed is False, (
+            "task.is_completed must be False after a failed stream — "
+            "otherwise the next invoke triggers the completed-task guard."
+        )
+        assert simple_task.is_problematic is True, (
+            "task.is_problematic must be True (status=error) so the "
+            "caller knows to continue/retry, not silently re-run."
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_error_appends_failing_step_to_step_results(self, agent, simple_task):
+        """When a streaming step raises, its ERROR StepResult must be
+        appended to context.step_results. Without this, observability
+        is broken and the buggy finally branch sees step_results[-1] as
+        the previous COMPLETED step.
+        """
+        from upsonic.agent.pipeline.step import StepStatus
+
+        agent.model = self._make_error_model()
+
+        with pytest.raises(Exception):
+            async for _ in agent.astream(simple_task):
+                pass
+
+        output = agent._agent_run_output
+        assert output is not None
+        assert output.step_results, "step_results must not be empty"
+        last_step = output.step_results[-1]
+        assert last_step.status in (StepStatus.ERROR, StepStatus.CANCELLED), (
+            f"Last recorded step status should be ERROR/CANCELLED after "
+            f"a mid-stream failure, got {last_step.status}. Failing step "
+            f"was never finalized into step_results."
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_error_records_failing_step_name(self, agent, simple_task):
+        """The recorded failing step must carry name/step_number so
+        observability (pipeline_failed panel, sentry log) and downstream
+        gates (continue_run_async) can identify where we failed.
+        """
+        agent.model = self._make_error_model()
+
+        with pytest.raises(Exception):
+            async for _ in agent.astream(simple_task):
+                pass
+
+        output = agent._agent_run_output
+        last_step = output.step_results[-1]
+        assert last_step.name, (
+            f"Failing StepResult must have a non-empty name, got "
+            f"{last_step.name!r}. StreamModelExecutionStep's exception "
+            f"branch was constructing StepResult without name/step_number."
+        )
+
+    @pytest.mark.asyncio
+    async def test_second_invoke_with_fresh_task_does_not_warn(self, agent, simple_task):
+        """After a failed stream, invoking with a *different* fresh Task
+        must not trip the completed-task guard. (Regression for the
+        cross-invocation symptom seen in autonomous-HQ chat.)
+        """
+        from upsonic.run.base import RunStatus
+
+        agent.model = self._make_error_model()
+
+        with pytest.raises(Exception):
+            async for _ in agent.astream(simple_task):
+                pass
+
+        # Restore a healthy model and stream a fresh task.
+        agent.model = MockModel()
+        fresh_task = Task(description="Second turn")
+
+        chunks = []
+        async for chunk in agent.astream(fresh_task):
+            chunks.append(chunk)
+
+        assert "".join(chunks) == "Hello world!"
+        assert fresh_task.status == RunStatus.completed
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- ``PipelineManager.execute_stream``'s ``finally`` ran ``mark_completed()`` after ``mark_error()`` because the failing step never made it into ``step_results`` — reusing the task then tripped the ``Task is already completed`` guard.
- ``Step.run_stream`` now finalises the failing step in ``finally``; manager gates ``mark_completed()`` on ``error_message is None``; ``pipeline_failed`` reports the real failing step name + time.
- Side fixes: ``Chat.reset_session`` clears its usage-registry entries; ``ModelHTTPError`` accepts a ``message`` override; Anthropic falls back to ``repr(e)`` on empty SDK messages.