### PR TITLE
feat(vectordb): add Valkey Search provider

### DIFF
--- a/documents/ai/explanation/chat/chat.md
+++ b/documents/ai/explanation/chat/chat.md
@@ -1,6 +1,6 @@
 ---
 name: chat-session-layer
-description: Use when working on the conversational session orchestrator that wraps an Agent with persisted multi-turn state under `src/upsonic/chat/`. Use when a user asks to build a Chat session, manage session_id/user_id with Storage, stream responses, retry failed invocations, edit chat history, remove attachments, compute session metrics/cost, or handle HITL paused runs. Trigger when the user mentions Chat, ChatMessage, ChatAttachment, SessionManager, SessionState, SessionMetrics, InvokeResult, CostTracker, format_cost, format_tokens, invoke, astream, blocking vs streaming, retry_attempts, max_concurrent_invocations, reopen_session, clear_history, remove_attachment, AgentRunOutput, RunUsage, or AgentSession in the chat package.
+description: Use when working on the conversational session orchestrator that wraps an Agent with persisted multi-turn state under `src/upsonic/chat/`. Use when a user asks to build a Chat session, manage session_id/user_id with Storage, stream responses, edit chat history, remove attachments, compute session metrics/cost, or handle HITL paused runs. Trigger when the user mentions Chat, ChatMessage, ChatAttachment, SessionManager, SessionState, SessionMetrics, InvokeResult, CostTracker, format_cost, format_tokens, invoke, astream, blocking vs streaming, max_concurrent_invocations, reopen_session, clear_history, remove_attachment, AgentRunOutput, RunUsage, or AgentSession in the chat package.
 ---
 
 # `src/upsonic/chat/` — Conversational Session Layer
@@ -260,7 +260,7 @@ The main public facade. Imports `Task`, `Memory`, `Storage`, `InMemoryStorage`, 
 
 ##### `__init__`
 
-Long signature broken into three groups (see table). All inputs are validated up front: empty strings raise `ValueError`, `agent is None` raises, `max_concurrent_invocations < 1`, `retry_attempts < 0`, `retry_delay < 0`, `num_last_messages < 1` (when not `None`) all raise.
+Long signature broken into three groups (see table). All inputs are validated up front: empty strings raise `ValueError`, `agent is None` raises, `max_concurrent_invocations < 1`, `num_last_messages < 1` (when not `None`) all raise.
 
 | Group | Parameters |
 | --- | --- |
@@ -270,7 +270,7 @@ Long signature broken into three groups (see table). All inputs are validated up
 | Memory load flags | `load_full_session_memory=True`, `load_summary_memory=None`, `load_user_analysis_memory=None` |
 | Profile config | `user_profile_schema=None`, `dynamic_user_profile=False` |
 | Memory tuning | `num_last_messages=None`, `feed_tool_call_results=False`, `user_memory_mode='update'\|'replace'` |
-| Chat ops | `debug=False`, `debug_level=1`, `max_concurrent_invocations=1`, `retry_attempts=3`, `retry_delay=1.0` |
+| Chat ops | `debug=False`, `debug_level=1`, `max_concurrent_invocations=1` |
 
 After validation it resolves storage and memory under an **agent-first** policy, then realigns its identifiers:
 
@@ -326,8 +326,6 @@ All forward to `_session_manager` — there is *no* duplicate state in `Chat`.
 | --- | --- |
 | `_transition_state(new_state)` | Thin wrapper over `_session_manager.transition_state`. |
 | `_normalize_input(input_data, context=None)` | `None` → `ValueError`; `str` → `Task(description=stripped, context=context)` (rejecting empty/whitespace); `Task` → returned as-is (with description validation); other → `TypeError`. |
-| `_execute_with_retry(coro_func, *args, **kwargs)` | Retry loop. On exception: classify via `_is_retryable_error`. Non-retryable → state to `ERROR`, re-raise. Retryable & attempts left → `await asyncio.sleep(retry_delay * 2 ** attempt)` (exponential backoff). All attempts exhausted → state to `ERROR`, raise the last exception. |
-| `_is_retryable_error(error)` | True if the error is `ConnectionError`, `TimeoutError`, `asyncio.TimeoutError`, or `OSError`, OR its lowercased message contains any of: `'timeout'`, `'connection'`, `'network'`, `'rate limit'`, `'temporary'`, `'service unavailable'`, `'internal server error'`, `'bad gateway'`, `'gateway timeout'`. |
 
 ##### `invoke` — the primary entry point
 
@@ -355,18 +353,16 @@ Runtime body:
 
 ##### `_invoke_blocking_async`
 
-Defines an inner `_execute()` coroutine. If `return_run_output`, calls `agent.do_async(task, debug=self.debug, return_output=True, **kwargs)`. If the result is an `AgentRunOutput` and `result.is_paused`, returns `InvokeResult(text=str(result.output), run_output=result)` — the HITL pause path. Otherwise returns `InvokeResult(text=…, run_output=None)`. If `return_run_output` is `False`, calls `agent.do_async(task, debug, **kwargs)` and stringifies the result. Wraps the call in `_execute_with_retry`. The `finally` always calls `end_response_timer`, `end_invocation`, and transitions state back to `IDLE`.
+Defines an inner `_execute()` coroutine. If `return_run_output`, calls `agent.do_async(task, debug=self.debug, return_output=True, **kwargs)`. If the result is an `AgentRunOutput` and `result.is_paused`, returns `InvokeResult(text=str(result.output), run_output=result)` — the HITL pause path. Otherwise returns `InvokeResult(text=…, run_output=None)`. If `return_run_output` is `False`, calls `agent.do_async(task, debug, **kwargs)` and stringifies the result. The `finally` always calls `end_response_timer`, `end_invocation`, and transitions state back to `IDLE`.
 
 ##### `_invoke_streaming` / `_invoke_streaming_events`
 
-Both follow the same pattern. They define an inner async generator (`_execute_streaming` / `_execute_streaming_events`) that calls `agent.astream(task, debug=self.debug, events=False/True, **kwargs)` and yields chunks (`str`) or `AgentEvent`s. Then they wrap that in `_stream_with_retry` / `_stream_events_with_retry`:
+Both follow the same pattern. They define an inner async generator that calls `agent.astream(task, debug=self.debug, events=False/True, **kwargs)` and yields chunks (`str`) or `AgentEvent`s.
 
-* For each attempt up to `_retry_attempts + 1`, get a fresh generator and `async for` through it, yielding to the caller.
-* On exception: best-effort `await stream_generator.aclose()` (suppressing close errors), null out the generator, then:
-  * If the message contains `"context manager is already active"` (a known pydantic-ai streaming corner case), backoff is `retry_delay * 3 ** attempt`.
-  * Else if attempts remain, backoff is `retry_delay * 2 ** attempt`.
-  * Else re-raise the last exception.
-* The outer `try/finally` always closes the generator if any, calls `end_response_timer`, `end_invocation`, and transitions to `IDLE`.
+* On exception: state transitions to `ERROR`, best-effort `await stream_generator.aclose()` (suppressing close errors), then re-raises.
+* The `finally` block always closes the generator if any, calls `end_response_timer`, `end_invocation`, and transitions to `IDLE`.
+
+Note: Retries are now owned by `Agent(retry=N)` via the `@retryable` decorator — `Chat` no longer implements its own retry logic.
 
 This means that even mid-stream cancellation, exceptions, or abandonment never leak open generators or stuck state.
 
@@ -476,10 +472,10 @@ text = await chat.invoke("Hello!")
 3. `_normalize_input("Hello!")` → `Task(description="Hello!")`.
 4. `start_invocation()` increments concurrent counter to `1`. State transitions to `AWAITING_RESPONSE`.
 5. `start_response_timer()` returns `t0 = time.time()`.
-6. `_invoke_blocking_async` runs `_execute_with_retry(_execute)`:
+6. `_invoke_blocking_async` runs `_execute`:
    * `_execute` calls `agent.do_async(task, debug=self.debug, **kwargs)` and stringifies the result.
    * The agent internally pulls history out of `Memory` (which reads `session.messages`), runs the model, writes back the new `ModelRequest` + `ModelResponse` and updates `session.usage`.
-   * Any retryable exception triggers exponential backoff (`retry_delay * 2 ** attempt`).
+   * Retries (if configured) are handled at the `Agent` level via `@retryable`.
 7. `_session_manager.end_response_timer(t0)` records the duration in `_response_times`.
 8. `finally`: `end_invocation()` decrements the counter; state → `IDLE`.
 9. Returns `text`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ supermemory = [
     "supermemory>=3.25.0",
 ]
 valkey = [
-    "valkey-glide>=2.3.1",
+    "valkey-glide>=2.4.0",
 ]
 vectordb = [
     "chromadb>=1.0.20; python_version < '3.14'",
@@ -85,7 +85,7 @@ vectordb = [
     "psycopg>=3.2.9",
     "pymilvus[milvus-lite]>=2.6.1",
     "qdrant-client>=1.12.1",
-    "valkey-glide>=2.3.1",
+    "valkey-glide>=2.4.0",
     "weaviate-client>=4.16.9",
     "scipy>=1.13.0",
     "scikit-learn>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests>=2.32.5",
     "openai>=2.2.0",
     "genai-prices>=0.0.38",
-    "protobuf>=5.27.2,<6.0.0",
+    "protobuf>=5.27.2,<7.0.0",
     "cloudpickle>=3.1.2",
 ]
 
@@ -75,6 +75,9 @@ pgvector = [
 supermemory = [
     "supermemory>=3.25.0",
 ]
+valkey = [
+    "valkey-glide>=2.3.1",
+]
 vectordb = [
     "chromadb>=1.0.20; python_version < '3.14'",
     "faiss-cpu>=1.12.0",
@@ -82,6 +85,7 @@ vectordb = [
     "psycopg>=3.2.9",
     "pymilvus[milvus-lite]>=2.6.1",
     "qdrant-client>=1.12.1",
+    "valkey-glide>=2.3.1",
     "weaviate-client>=4.16.9",
     "scipy>=1.13.0",
     "scikit-learn>=1.4.0",

--- a/src/upsonic/chat/chat.py
+++ b/src/upsonic/chat/chat.py
@@ -117,7 +117,6 @@ class Chat:
         debug: bool = False,
         debug_level: int = 1,
         max_concurrent_invocations: int = 1,
-        chat_usage_id: Optional[str] = None,
     ) -> None:
         """
         Initialize a Chat session.
@@ -156,9 +155,6 @@ class Chat:
         self.agent = agent
         self.debug = debug
         self.debug_level = debug_level if debug else 1
-
-        from upsonic.usage_registry import new_usage_id
-        self.chat_usage_id: str = chat_usage_id or new_usage_id("chat")
         
         # Agent-first resolution: reuse agent.memory (and its storage) when
         # present; otherwise build a fresh pair from Chat's kwargs and wire
@@ -220,21 +216,6 @@ class Chat:
         
         self._max_concurrent_invocations = max_concurrent_invocations
 
-        # Wire the resolved storage into the default usage registry so
-        # every entry recorded under this chat_usage_id is also persisted
-        # and historical spend is restored on reopen. Backends that have
-        # not been ported to Phase 4 silently no-op via the
-        # NotImplementedError-swallowing path on the registry side.
-        try:
-            from upsonic.usage_registry import get_default_registry
-            if self._storage is not None:
-                _registry = get_default_registry()
-                _registry.attach_storage(self._storage)
-                _registry.load_from_storage(chat_usage_id=self.chat_usage_id)
-        except Exception:
-            # Never let registry wiring break Chat construction.
-            pass
-
         # Tracks the currently-active streaming generator (if any) so the
         # next invoke can force-close a stream the consumer abandoned
         # without calling `aclose()`. Only honoured when
@@ -282,28 +263,46 @@ class Chat:
         """
         return self._session_manager.all_messages
     
-    # ------------------------------------------------------------------
-    # Usage / cost / token surface
-    # ------------------------------------------------------------------
-    #
-    # One canonical surface: ``chat.usage`` returns an
-    # :class:`AggregatedUsage` view of every UsageEntry tagged with this
-    # chat's ``chat_usage_id`` (sub-agent / memory / reliability calls
-    # inherit the scope automatically, so this picks them up too).
-    #
-    # All token / cost / duration / TTFT / request / tool-call counts
-    # are fields on that view — read them as ``chat.usage.input_tokens``,
-    # ``chat.usage.cost``, ``chat.usage.duration``, etc. The previous
-    # top-level shortcuts (``chat.input_tokens`` / ``chat.total_cost`` /
-    # …) and ``chat.get_usage()`` / ``chat.get_session_metrics()`` were
-    # removed in the unification pass — every other entity (Agent,
-    # Task, AgentRunOutput) uses the same ``.usage.X`` shape now.
-
     @property
-    def usage(self):
-        from upsonic.usage_registry import get_default_registry
-        return get_default_registry().by_chat(self.chat_usage_id)
-
+    def input_tokens(self) -> int:
+        """Total input tokens used in this chat session (from storage)."""
+        return self._session_manager.input_tokens
+    
+    @property
+    def output_tokens(self) -> int:
+        """Total output tokens used in this chat session (from storage)."""
+        return self._session_manager.output_tokens
+    
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens (input + output) used in this chat session."""
+        return self._session_manager.total_tokens
+    
+    @property
+    def total_cost(self) -> float:
+        """Total cost of this chat session in USD (from storage)."""
+        return self._session_manager.total_cost
+    
+    @property
+    def total_requests(self) -> int:
+        """Total API requests made in this chat session (from storage)."""
+        return self._session_manager.total_requests
+    
+    @property
+    def total_tool_calls(self) -> int:
+        """Total tool calls made in this chat session (from storage)."""
+        return self._session_manager.total_tool_calls
+    
+    @property
+    def run_duration(self) -> Optional[float]:
+        """Total run duration in seconds (from storage RunUsage)."""
+        return self._session_manager.run_duration
+    
+    @property
+    def time_to_first_token(self) -> Optional[float]:
+        """Time to first token in seconds (from storage RunUsage)."""
+        return self._session_manager.time_to_first_token
+    
     @property
     def start_time(self) -> float:
         """Session start time (Unix timestamp)."""
@@ -338,6 +337,18 @@ class Chat:
     def is_closed(self) -> bool:
         """Check if the session has been closed."""
         return self._session_manager.is_closed
+    
+    def get_usage(self) -> Any:
+        """Get the full RunUsage object from session storage."""
+        return self._session_manager.get_usage()
+    
+    def get_session_metrics(self) -> Any:
+        """Get comprehensive session metrics."""
+        return self._session_manager.get_session_metrics()
+    
+    def get_session_summary(self) -> str:
+        """Get a human-readable session summary."""
+        return self._session_manager.get_session_summary()
     
     def get_recent_messages(self, count: int = 10) -> List[ChatMessage]:
         """Get the most recent messages as ChatMessage objects."""
@@ -717,12 +728,7 @@ class Chat:
     ) -> Union[str, InvokeResult]:
         """Handle blocking invocation. Retries are owned by ``agent.retry``."""
         from upsonic.run.agent.output import AgentRunOutput as AgentRunOutputConcrete
-        from upsonic.usage_registry import push_scope_tags
 
-        _scope_tokens = push_scope_tags(
-            chat_usage_id=self.chat_usage_id,
-            user_id=self.user_id,
-        )
         try:
             if self.debug and self.debug_level >= 2:
                 from upsonic.utils.printing import debug_log_level2
@@ -774,8 +780,52 @@ class Chat:
         finally:
             self._session_manager.end_invocation()
             self._transition_state(SessionState.IDLE)
-            from upsonic.usage_registry import reset_scope_tags
-            reset_scope_tags(_scope_tokens)
+    
+    def _invoke_streaming_impl(
+        self,
+        task: Task,
+        response_start_time: float,
+        events: bool,
+        **kwargs: Any
+    ) -> AsyncIterator[Any]:
+        """Shared streaming implementation for both text chunks and event objects."""
+        async def _stream() -> AsyncIterator[Any]:
+            stream_generator: Optional[AsyncIterator[Any]] = None
+            try:
+                stream_generator = self.agent.astream(task, debug=self.debug, events=events, **kwargs)
+                async for item in stream_generator:
+                    if not events:
+                        # Text mode: only yield string chunks
+                        if isinstance(item, str):
+                            yield item
+                    else:
+                        yield item
+            except Exception:
+                self._transition_state(SessionState.ERROR)
+                if stream_generator is not None:
+                    try:
+                        await stream_generator.aclose()
+                    except Exception:
+                        pass
+                    stream_generator = None
+                raise
+            finally:
+                # Counter / state first — sync, GeneratorExit-safe.
+                self._session_manager.end_response_timer(response_start_time)
+                self._session_manager.end_invocation()
+                self._transition_state(SessionState.IDLE)
+                if self._active_stream is gen:
+                    self._active_stream = None
+
+                if stream_generator is not None:
+                    try:
+                        await stream_generator.aclose()
+                    except Exception:
+                        pass
+
+        gen = _stream()
+        self._active_stream = gen
+        return gen
 
     def _invoke_streaming(
         self,
@@ -784,48 +834,8 @@ class Chat:
         **kwargs: Any
     ) -> AsyncIterator[str]:
         """Handle streaming invocation (text chunks)."""
-        from upsonic.usage_registry import push_scope_tags, reset_scope_tags
+        return self._invoke_streaming_impl(task, response_start_time, events=False, **kwargs)
 
-        async def _stream() -> AsyncIterator[str]:
-            _scope_tokens = push_scope_tags(
-                chat_usage_id=self.chat_usage_id,
-                user_id=self.user_id,
-            )
-            stream_generator: Optional[AsyncIterator[Any]] = None
-            try:
-                stream_generator = self.agent.astream(task, debug=self.debug, events=False, **kwargs)
-                async for chunk in stream_generator:
-                    if isinstance(chunk, str):
-                        yield chunk
-            except Exception:
-                self._transition_state(SessionState.ERROR)
-                if stream_generator is not None:
-                    try:
-                        await stream_generator.aclose()
-                    except Exception:
-                        pass
-                    stream_generator = None
-                raise
-            finally:
-                # Counter / state first — sync, GeneratorExit-safe.
-                self._session_manager.end_response_timer(response_start_time)
-                self._session_manager.end_invocation()
-                self._transition_state(SessionState.IDLE)
-                if self._active_stream is gen:
-                    self._active_stream = None
-
-                if stream_generator is not None:
-                    try:
-                        await stream_generator.aclose()
-                    except Exception:
-                        pass
-
-                reset_scope_tags(_scope_tokens)
-
-        gen = _stream()
-        self._active_stream = gen
-        return gen
-    
     def _invoke_streaming_events(
         self,
         task: Task,
@@ -833,46 +843,7 @@ class Chat:
         **kwargs: Any
     ) -> AsyncIterator["AgentEvent"]:
         """Handle streaming invocation with events (yields AgentEvent objects)."""
-        from upsonic.usage_registry import push_scope_tags, reset_scope_tags
-
-        async def _stream() -> AsyncIterator[Any]:
-            _scope_tokens = push_scope_tags(
-                chat_usage_id=self.chat_usage_id,
-                user_id=self.user_id,
-            )
-            stream_generator: Optional[AsyncIterator[Any]] = None
-            try:
-                stream_generator = self.agent.astream(task, debug=self.debug, events=True, **kwargs)
-                async for event in stream_generator:
-                    yield event
-            except Exception:
-                self._transition_state(SessionState.ERROR)
-                if stream_generator is not None:
-                    try:
-                        await stream_generator.aclose()
-                    except Exception:
-                        pass
-                    stream_generator = None
-                raise
-            finally:
-                # Counter / state first — sync, GeneratorExit-safe.
-                self._session_manager.end_response_timer(response_start_time)
-                self._session_manager.end_invocation()
-                self._transition_state(SessionState.IDLE)
-                if self._active_stream is gen:
-                    self._active_stream = None
-
-                if stream_generator is not None:
-                    try:
-                        await stream_generator.aclose()
-                    except Exception:
-                        pass
-
-                reset_scope_tags(_scope_tokens)
-
-        gen = _stream()
-        self._active_stream = gen
-        return gen
+        return self._invoke_streaming_impl(task, response_start_time, events=True, **kwargs)
     
     @overload
     def stream(
@@ -962,9 +933,8 @@ class Chat:
     def __repr__(self) -> str:
         """String representation of the chat."""
         message_count = self._session_manager.get_message_count()
-        cost = self.usage.cost or 0.0
         return (
             f"Chat(session_id='{self.session_id}', user_id='{self.user_id}', "
             f"state={self.state.value}, messages={message_count}, "
-            f"cost=${cost:.4f})"
+            f"cost=${self.total_cost:.4f})"
         )

--- a/src/upsonic/vectordb/__init__.py
+++ b/src/upsonic/vectordb/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         WeaviateConfig,
         PgVectorConfig,
         SuperMemoryConfig,
+        ValkeyConfig,
         create_config,
     )
 
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from .providers.weaviate import WeaviateProvider
     from .providers.pgvector import PgVectorProvider
     from .providers.supermemory import SuperMemoryProvider
+    from .providers.valkey import ValkeyProvider
 
 # Provider class mapping for lazy imports
 _PROVIDER_MAP = {
@@ -45,6 +47,7 @@ _PROVIDER_MAP = {
     'WeaviateProvider': '.providers.weaviate',
     'PgVectorProvider': '.providers.pgvector',
     'SuperMemoryProvider': '.providers.supermemory',
+    'ValkeyProvider': '.providers.valkey',
 }
 
 # Cache for lazily imported providers and configs
@@ -81,6 +84,7 @@ def _get_config_classes():
         WeaviateConfig,
         PgVectorConfig,
         SuperMemoryConfig,
+        ValkeyConfig,
         create_config,
     )
     
@@ -102,6 +106,7 @@ def _get_config_classes():
         'WeaviateConfig': WeaviateConfig,
         'PgVectorConfig': PgVectorConfig,
         'SuperMemoryConfig': SuperMemoryConfig,
+        'ValkeyConfig': ValkeyConfig,
         'create_config': create_config,
     })
     
@@ -165,6 +170,7 @@ __all__ = [
     'WeaviateProvider',
     'PgVectorProvider',
     'SuperMemoryProvider',
+    'ValkeyProvider',
     
     # Config classes
     'BaseVectorDBConfig',
@@ -184,6 +190,7 @@ __all__ = [
     'WeaviateConfig',
     'PgVectorConfig',
     'SuperMemoryConfig',
+    'ValkeyConfig',
     'create_config',
 ]
 

--- a/src/upsonic/vectordb/config.py
+++ b/src/upsonic/vectordb/config.py
@@ -562,6 +562,59 @@ class SuperMemoryConfig(BaseVectorDBConfig):
         return cls(**config_dict)
 
 
+class ValkeyConfig(BaseVectorDBConfig):
+    """
+    Configuration for Valkey Search vector database provider.
+
+    Requires Valkey 9.1+ with the valkey-search module (v1.2+) loaded.
+    Supports HNSW and FLAT indexes, dense vector search, full-text search,
+    and hybrid search combining both via RRF fusion.
+
+    Documents are stored as Valkey Hash keys with a configurable prefix.
+    The FT index is created over those hashes with vector, text, and tag fields.
+    """
+    connection: ConnectionConfig
+    index: Union[HNSWIndexConfig, FlatIndexConfig] = HNSWIndexConfig()
+
+    # Key prefix for hash keys storing document chunks
+    key_prefix: str = "doc:"
+
+    # Vector field configuration
+    vector_field_name: str = "vector"
+
+    # Full-text search field
+    text_field_name: str = "content"
+
+    # HNSW runtime search parameter
+    ef_runtime: Optional[int] = None
+
+    # Batch processing
+    batch_size: int = 100
+
+    # Cluster mode (use GlideClusterClient instead of GlideClient)
+    cluster_mode: bool = False
+
+    # Request timeout in milliseconds for the GLIDE client
+    request_timeout: Optional[int] = None
+
+    # Hybrid search RRF ranking parameter
+    rrf_k: int = 60
+
+    @pydantic.model_validator(mode='after')
+    def validate_valkey_config(self):
+        """Validate Valkey-specific constraints."""
+        if isinstance(self.index, IVFIndexConfig):
+            raise ValueError("Valkey Search does not support IVF index type. Use HNSW or FLAT.")
+        if self.vector_size <= 0:
+            raise ValueError("vector_size must be a positive integer for Valkey Search.")
+        return self
+
+    @classmethod
+    def from_dict(cls, config_dict: Dict[str, Any]) -> 'ValkeyConfig':
+        """Create ValkeyConfig from a dictionary."""
+        return cls(**config_dict)
+
+
 Config = Union[
     ChromaConfig,
     FaissConfig,
@@ -571,6 +624,7 @@ Config = Union[
     WeaviateConfig,
     PgVectorConfig,
     SuperMemoryConfig,
+    ValkeyConfig,
 ]
 
 
@@ -595,6 +649,7 @@ def create_config(provider: str, **kwargs) -> Config:
         'weaviate': WeaviateConfig,
         'pgvector': PgVectorConfig,
         'supermemory': SuperMemoryConfig,
+        'valkey': ValkeyConfig,
     }
     
     config_class = provider_map.get(provider.lower())

--- a/src/upsonic/vectordb/providers/valkey.py
+++ b/src/upsonic/vectordb/providers/valkey.py
@@ -1,0 +1,1131 @@
+"""
+Valkey Search Provider Implementation
+
+A comprehensive, async-first vector database provider for Valkey with the
+valkey-search module (v1.2+). Uses valkey-glide as the client library.
+
+Requires Valkey 9.1+ with the search module loaded.
+
+Standard properties stored per hash key ({key_prefix}{chunk_id}):
+- vector (VECTOR, float32 blob) — the embedding vector
+- content (TEXT) — the chunk text, full-text indexed
+- chunk_id (TAG) — unique per-chunk identifier
+- document_id (TAG) — parent document identifier
+- document_name (TAG) — human-readable source name
+- doc_content_hash (TAG) — MD5 of parent document content for change detection
+- chunk_content_hash (TAG) — MD5 of chunk text content for deduplication
+- knowledge_base_id (TAG) — KnowledgeBase isolation
+- metadata (TEXT) — JSON-serialized non-standard metadata
+
+This implementation provides:
+- Full async/await support using valkey-glide (GlideClient)
+- HNSW and FLAT vector index support
+- Dense (KNN), full-text, and hybrid search
+- Content-based deduplication via chunk_content_hash
+- Batch upsert operations via pipelining
+- Cluster mode support via GlideClusterClient
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import struct
+import uuid as _uuid
+from typing import Any, Dict, List, Optional, Union, Literal, cast, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from glide import (
+        GlideClient,
+        GlideClusterClient,
+        GlideClientConfiguration,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        FtCreateOptions,
+        FtSearchOptions,
+        FtSearchLimit,
+        ReturnField,
+        VectorField,
+        VectorFieldAttributesHnsw,
+        VectorFieldAttributesFlat,
+        VectorAlgorithm,
+        DistanceMetricType,
+        VectorType,
+        TextField,
+        TagField,
+    )
+
+try:
+    from glide import (
+        GlideClient,
+        GlideClusterClient,
+        GlideClientConfiguration,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        FtCreateOptions,
+        FtSearchOptions,
+        FtSearchLimit,
+        ReturnField,
+        VectorField,
+        VectorFieldAttributesHnsw,
+        VectorFieldAttributesFlat,
+        VectorAlgorithm,
+        DistanceMetricType,
+        VectorType,
+        TextField,
+        TagField,
+        ft,
+    )
+    _VALKEY_GLIDE_AVAILABLE = True
+except ImportError:
+    _VALKEY_GLIDE_AVAILABLE = False
+
+from upsonic.vectordb.base import BaseVectorDBProvider
+from upsonic.vectordb.config import (
+    ValkeyConfig,
+    Mode,
+    DistanceMetric,
+    HNSWIndexConfig,
+    FlatIndexConfig,
+)
+from upsonic.schemas.vector_schemas import VectorSearchResult
+from upsonic.utils.logging_config import get_logger
+from upsonic.utils.printing import info_log, debug_log
+from upsonic.utils.package.exception import (
+    VectorDBConnectionError,
+    VectorDBError,
+    CollectionDoesNotExistError,
+    ConfigurationError,
+    SearchError,
+    UpsertError,
+)
+
+logger = get_logger(__name__)
+
+
+class ValkeyProvider(BaseVectorDBProvider):
+    """
+    Valkey Search vector database provider using valkey-glide.
+
+    Async-native implementation using GLIDE's built-in FT.* module API.
+    Stores documents as Valkey Hash keys with vector, content, and metadata fields.
+
+    Supports:
+    - HNSW and FLAT vector indexes
+    - Dense (KNN) vector similarity search
+    - Full-text search via Valkey Search text fields
+    - Hybrid search combining dense + full-text via RRF fusion
+    - Content-based deduplication
+    - Cluster mode
+    """
+
+    _STANDARD_FIELDS: frozenset = frozenset({
+        'chunk_id', 'document_id', 'doc_content_hash',
+        'chunk_content_hash', 'document_name', 'content', 'metadata',
+        'knowledge_base_id',
+    })
+
+    def __init__(
+        self,
+        config: Union[ValkeyConfig, Dict[str, Any]],
+        reranker: Optional[Any] = None,
+    ) -> None:
+        if not _VALKEY_GLIDE_AVAILABLE:
+            from upsonic.utils.printing import import_error
+            import_error(
+                package_name="valkey-glide",
+                install_command='pip install "upsonic[valkey]"',
+                feature_name="Valkey Search vector database provider",
+            )
+
+        if isinstance(config, dict):
+            config = ValkeyConfig.from_dict(config)
+
+        if not isinstance(config, ValkeyConfig):
+            raise ConfigurationError(
+                "config must be either a ValkeyConfig instance or a dictionary"
+            )
+
+        super().__init__(config)
+        self._config: ValkeyConfig = cast(ValkeyConfig, self._config)
+        self.client: Optional[Any] = None
+        self.reranker: Optional[Any] = reranker
+
+        self._index_name: str = self._config.collection_name
+        self._key_prefix: str = self._config.key_prefix
+
+        logger.info(
+            f"Initialized ValkeyProvider for index '{self._index_name}' "
+            f"(key_prefix: '{self._key_prefix}')"
+        )
+
+    # ========================================================================
+    # Helpers
+    # ========================================================================
+
+    def _get_distance_metric(self) -> "DistanceMetricType":
+        """Map framework DistanceMetric to GLIDE DistanceMetricType."""
+        metric_map = {
+            DistanceMetric.COSINE: DistanceMetricType.COSINE,
+            DistanceMetric.EUCLIDEAN: DistanceMetricType.L2,
+            DistanceMetric.DOT_PRODUCT: DistanceMetricType.IP,
+        }
+        return metric_map[self._config.distance_metric]
+
+    def _vector_to_bytes(self, vector: List[float]) -> bytes:
+        """Convert a list of floats to a float32 binary blob for Valkey."""
+        return struct.pack(f"<{len(vector)}f", *vector)
+
+    def _bytes_to_vector(self, data: bytes) -> List[float]:
+        """Convert a float32 binary blob back to a list of floats."""
+        count = len(data) // 4
+        return list(struct.unpack(f"<{count}f", data))
+
+    def _make_key(self, chunk_id: str) -> str:
+        """Build the full hash key for a chunk."""
+        return f"{self._key_prefix}{chunk_id}"
+
+    def _distance_to_similarity(self, distance: float) -> float:
+        """Convert a distance score to a similarity score in [0, 1].
+
+        For COSINE: Valkey returns 1 - cosine_similarity, range [0, 2].
+        For DOT_PRODUCT (IP): Valkey returns 1 - inner_product. Can be negative
+            for vectors with negative components; clamped to [0, 1].
+        For L2: Lower distance = more similar; uses inverse transform.
+        """
+        if self._config.distance_metric == DistanceMetric.COSINE:
+            return max(0.0, min(1.0, 1.0 - distance))
+        elif self._config.distance_metric == DistanceMetric.DOT_PRODUCT:
+            return max(0.0, min(1.0, 1.0 - distance))
+        else:
+            return 1.0 / (1.0 + distance)
+
+    # ========================================================================
+    # Connection Lifecycle
+    # ========================================================================
+
+    async def aconnect(self) -> None:
+        """Connect to Valkey using GLIDE client."""
+        if self._is_connected and self.client is not None:
+            logger.info("Already connected to Valkey.")
+            return
+
+        try:
+            conn = self._config.connection
+            addresses = []
+
+            if conn.url:
+                # Parse URL for host/port
+                from urllib.parse import urlparse
+                parsed = urlparse(conn.url)
+                host = parsed.hostname or "localhost"
+                port = parsed.port or 6379
+                addresses.append(NodeAddress(host, port))
+            elif conn.host and conn.port is not None:
+                addresses.append(NodeAddress(conn.host, conn.port))
+            elif conn.mode == Mode.IN_MEMORY:
+                # IN_MEMORY mode: connect to localhost default
+                addresses.append(NodeAddress("localhost", 6379))
+            else:
+                addresses.append(NodeAddress("localhost", 6379))
+
+            kwargs: Dict[str, Any] = {"addresses": addresses}
+            if self._config.request_timeout is not None:
+                kwargs["request_timeout"] = self._config.request_timeout
+
+            if self._config.cluster_mode:
+                client_config = GlideClusterClientConfiguration(**kwargs)
+                self.client = await GlideClusterClient.create(client_config)
+            else:
+                client_config = GlideClientConfiguration(**kwargs)
+                self.client = await GlideClient.create(client_config)
+
+            self._is_connected = True
+            logger.info("Successfully connected to Valkey")
+
+        except Exception as e:
+            self.client = None
+            self._is_connected = False
+            raise VectorDBConnectionError(
+                f"Failed to connect to Valkey: {e}"
+            ) from e
+
+    async def adisconnect(self) -> None:
+        """Disconnect from Valkey."""
+        try:
+            if self.client is not None:
+                await self.client.close()
+                self.client = None
+            self._is_connected = False
+            logger.info("Disconnected from Valkey")
+        except Exception as e:
+            logger.error(f"Error during disconnect: {e}")
+            raise VectorDBError(f"Disconnect failed: {e}") from e
+
+    async def ais_ready(self) -> bool:
+        """Check if the Valkey connection is alive."""
+        if not self._is_connected or self.client is None:
+            return False
+        try:
+            result = await self.client.ping()
+            return result == b"PONG" or result == "PONG"
+        except Exception:
+            return False
+
+    # ========================================================================
+    # Collection Lifecycle (FT.CREATE / FT.DROPINDEX)
+    # ========================================================================
+
+    async def acreate_collection(self) -> None:
+        """Create the FT index over hash keys with the configured schema."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        exists = await self.acollection_exists()
+        if exists:
+            if self._config.recreate_if_exists:
+                logger.info(f"Index '{self._index_name}' exists, recreating...")
+                await self.adelete_collection()
+            else:
+                logger.info(f"Index '{self._index_name}' already exists")
+                return
+
+        try:
+            # Build schema fields
+            schema: List[Any] = []
+
+            # Vector field
+            dim = self._config.vector_size
+            metric = self._get_distance_metric()
+
+            if isinstance(self._config.index, HNSWIndexConfig):
+                hnsw_cfg = self._config.index
+                attrs = VectorFieldAttributesHnsw(
+                    dimensions=dim,
+                    distance_metric=metric,
+                    type=VectorType.FLOAT32,
+                    number_of_edges=hnsw_cfg.m,
+                    vectors_examined_on_construction=hnsw_cfg.ef_construction,
+                    vectors_examined_on_runtime=self._config.ef_runtime,
+                )
+                schema.append(VectorField(
+                    name=self._config.vector_field_name,
+                    algorithm=VectorAlgorithm.HNSW,
+                    attributes=attrs,
+                ))
+            else:
+                attrs_flat = VectorFieldAttributesFlat(
+                    dimensions=dim,
+                    distance_metric=metric,
+                    type=VectorType.FLOAT32,
+                )
+                schema.append(VectorField(
+                    name=self._config.vector_field_name,
+                    algorithm=VectorAlgorithm.FLAT,
+                    attributes=attrs_flat,
+                ))
+
+            # Text field for full-text search
+            schema.append(TextField(name=self._config.text_field_name))
+
+            # Tag fields for filtering and existence checks
+            for tag_name in [
+                "chunk_id", "document_id", "document_name",
+                "doc_content_hash", "chunk_content_hash", "knowledge_base_id",
+            ]:
+                schema.append(TagField(name=tag_name, separator="|"))
+
+            # Create options with prefix
+            options = FtCreateOptions(prefixes=[self._key_prefix])
+
+            await ft.create(self.client, self._index_name, schema, options)
+            logger.info(f"Successfully created index '{self._index_name}'")
+
+        except Exception as e:
+            if "Index already exists" in str(e):
+                logger.info(f"Index '{self._index_name}' already exists")
+                return
+            logger.error(f"Failed to create index: {e}")
+            raise VectorDBError(f"Index creation failed: {e}") from e
+
+    async def adelete_collection(self) -> None:
+        """Drop the FT index. Does NOT delete the underlying hash keys."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            await ft.dropindex(self.client, self._index_name)
+            logger.info(f"Successfully dropped index '{self._index_name}'")
+        except Exception as e:
+            if "Unknown index" in str(e) or "not found" in str(e).lower():
+                raise CollectionDoesNotExistError(
+                    f"Index '{self._index_name}' does not exist"
+                ) from e
+            raise VectorDBError(f"Failed to drop index: {e}") from e
+
+    async def acollection_exists(self) -> bool:
+        """Check if the FT index exists."""
+        if self.client is None:
+            return False
+        try:
+            indexes = await ft.list(self.client)
+            names = {
+                i.decode() if isinstance(i, bytes) else str(i)
+                for i in (indexes or [])
+            }
+            return self._index_name in names
+        except Exception:
+            return False
+
+    # ========================================================================
+    # Data Operations
+    # ========================================================================
+
+    async def aupsert(
+        self,
+        vectors: Optional[List[List[float]]] = None,
+        payloads: Optional[List[Dict[str, Any]]] = None,
+        ids: Optional[List[Union[str, int]]] = None,
+        chunks: Optional[List[str]] = None,
+        document_ids: Optional[List[str]] = None,
+        document_names: Optional[List[str]] = None,
+        doc_content_hashes: Optional[List[str]] = None,
+        chunk_content_hashes: Optional[List[str]] = None,
+        sparse_vectors: Optional[List[Dict[str, Any]]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        knowledge_base_ids: Optional[List[str]] = None,
+    ) -> None:
+        """Upsert vectors and metadata as Valkey Hash keys."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        if vectors is None or len(vectors) == 0:
+            info_log("Nothing to upsert: no vectors provided.", context="ValkeyDB")
+            return
+
+        n = len(vectors)
+
+        # Validate lengths
+        for name, arr in (
+            ("payloads", payloads),
+            ("ids", ids),
+            ("chunks", chunks),
+            ("document_ids", document_ids),
+            ("document_names", document_names),
+            ("doc_content_hashes", doc_content_hashes),
+            ("chunk_content_hashes", chunk_content_hashes),
+            ("knowledge_base_ids", knowledge_base_ids),
+        ):
+            if arr is not None and len(arr) != n:
+                raise ValueError(
+                    f"Length mismatch: '{name}' has {len(arr)} items, expected {n}"
+                )
+
+        try:
+            records: List[Dict[str, Any]] = []
+            keys: List[str] = []
+            for i in range(n):
+                content = chunks[i] if chunks and i < len(chunks) else ""
+                chunk_id = str(ids[i]) if ids and i < len(ids) else str(_uuid.uuid4())
+                chunk_hash = (
+                    chunk_content_hashes[i]
+                    if chunk_content_hashes and i < len(chunk_content_hashes)
+                    else hashlib.md5(content.encode("utf-8")).hexdigest()
+                )
+                doc_id = document_ids[i] if document_ids and i < len(document_ids) else ""
+                doc_name = document_names[i] if document_names and i < len(document_names) else ""
+                doc_hash = doc_content_hashes[i] if doc_content_hashes and i < len(doc_content_hashes) else ""
+                kbi = knowledge_base_ids[i] if knowledge_base_ids and i < len(knowledge_base_ids) else ""
+
+                # Build metadata from payload
+                payload = payloads[i] if payloads and i < len(payloads) else {}
+                combined_metadata: Dict[str, Any] = {}
+                nested_meta = payload.get("metadata")
+                if isinstance(nested_meta, dict):
+                    combined_metadata.update(nested_meta)
+                for key, value in payload.items():
+                    if key in self._STANDARD_FIELDS or key == "metadata":
+                        continue
+                    combined_metadata[key] = value
+                if metadata:
+                    combined_metadata.update(metadata)
+
+                # Build hash fields
+                vector_bytes = self._vector_to_bytes(vectors[i])
+                hash_key = self._make_key(chunk_id)
+
+                field_map: Dict[str, Any] = {
+                    self._config.vector_field_name: vector_bytes,
+                    self._config.text_field_name: content,
+                    "chunk_id": chunk_id,
+                    "document_id": doc_id,
+                    "document_name": doc_name,
+                    "doc_content_hash": doc_hash,
+                    "chunk_content_hash": chunk_hash,
+                    "knowledge_base_id": kbi,
+                    "metadata": json.dumps(combined_metadata) if combined_metadata else "{}",
+                }
+
+                records.append(field_map)
+                keys.append(hash_key)
+
+            # Batch upsert using asyncio.gather in chunks of batch_size
+            batch_size = self._config.batch_size
+            for batch_start in range(0, len(records), batch_size):
+                batch_end = min(batch_start + batch_size, len(records))
+                coros = [
+                    self.client.hset(keys[i], records[i])
+                    for i in range(batch_start, batch_end)
+                ]
+                await asyncio.gather(*coros)
+
+            logger.info(f"Successfully upserted {n} records")
+
+        except UpsertError:
+            raise
+        except Exception as e:
+            logger.error(f"Upsert failed: {e}")
+            raise UpsertError(f"Failed to upsert data: {e}") from e
+
+    async def adelete(self, ids: List[Union[str, int]]) -> None:
+        """Delete records by their chunk IDs (deletes the hash keys)."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        if not ids:
+            return
+
+        try:
+            keys = [self._make_key(str(i)) for i in ids]
+            await self.client.unlink(keys)
+            logger.info(f"Deleted {len(keys)} records")
+        except Exception as e:
+            logger.error(f"Delete failed: {e}")
+            raise VectorDBError(f"Failed to delete records: {e}") from e
+
+    async def afetch(self, ids: List[Union[str, int]]) -> List[VectorSearchResult]:
+        """Fetch records by their chunk IDs."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        if not ids:
+            return []
+
+        results: List[VectorSearchResult] = []
+        try:
+            for record_id in ids:
+                key = self._make_key(str(record_id))
+                data = await self.client.hgetall(key)
+                if not data:
+                    continue
+
+                # Decode the hash fields
+                fields = self._decode_hash_fields(data)
+                vector = None
+                vector_bytes = fields.get(self._config.vector_field_name)
+                if isinstance(vector_bytes, bytes):
+                    vector = self._bytes_to_vector(vector_bytes)
+
+                results.append(VectorSearchResult(
+                    id=fields.get("chunk_id", str(record_id)),
+                    score=1.0,
+                    payload=self._fields_to_payload(fields),
+                    vector=vector,
+                    text=fields.get(self._config.text_field_name, ""),
+                ))
+
+            return results
+
+        except Exception as e:
+            logger.error(f"Fetch failed: {e}")
+            raise VectorDBError(f"Failed to fetch records: {e}") from e
+
+    def _decode_hash_fields(self, data: Any) -> Dict[str, Any]:
+        """Decode hash field data from GLIDE response to a string-keyed dict."""
+        decoded: Dict[str, Any] = {}
+        if isinstance(data, dict):
+            for k, v in data.items():
+                key_str = k.decode("utf-8") if isinstance(k, bytes) else str(k)
+                # Keep vector field as bytes for later conversion
+                if key_str == self._config.vector_field_name:
+                    decoded[key_str] = v if isinstance(v, bytes) else v
+                else:
+                    decoded[key_str] = v.decode("utf-8") if isinstance(v, bytes) else str(v)
+        return decoded
+
+    def _fields_to_payload(self, fields: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert decoded hash fields to the standard payload format."""
+        meta_str = fields.get("metadata", "{}")
+        try:
+            meta = json.loads(meta_str) if isinstance(meta_str, str) else {}
+        except (json.JSONDecodeError, TypeError):
+            meta = {}
+
+        return {
+            "chunk_id": fields.get("chunk_id", ""),
+            "document_id": fields.get("document_id", ""),
+            "document_name": fields.get("document_name", ""),
+            "content": fields.get(self._config.text_field_name, ""),
+            "doc_content_hash": fields.get("doc_content_hash", ""),
+            "chunk_content_hash": fields.get("chunk_content_hash", ""),
+            "knowledge_base_id": fields.get("knowledge_base_id", ""),
+            "metadata": meta,
+        }
+
+    # ========================================================================
+    # Search Operations
+    # ========================================================================
+
+    async def asearch(
+        self,
+        top_k: Optional[int] = None,
+        query_vector: Optional[List[float]] = None,
+        query_text: Optional[str] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        alpha: Optional[float] = None,
+        fusion_method: Optional[Literal['rrf', 'weighted']] = None,
+        similarity_threshold: Optional[float] = None,
+        apply_reranking: bool = True,
+        sparse_query_vector: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorSearchResult]:
+        """Route to the appropriate search method based on inputs."""
+        top_k = top_k if top_k is not None else self._config.default_top_k
+        similarity_threshold = (
+            similarity_threshold if similarity_threshold is not None
+            else self._config.default_similarity_threshold
+        )
+
+        has_vector = query_vector is not None
+        has_text = query_text is not None and query_text.strip() != ""
+
+        if has_vector and has_text:
+            if not self._config.hybrid_search_enabled:
+                raise ConfigurationError("Hybrid search is disabled in configuration")
+            return await self.ahybrid_search(
+                query_vector=query_vector,
+                query_text=query_text,
+                top_k=top_k,
+                filter=filter,
+                alpha=alpha,
+                fusion_method=fusion_method,
+                similarity_threshold=similarity_threshold,
+                apply_reranking=apply_reranking,
+                sparse_query_vector=sparse_query_vector,
+            )
+        elif has_vector:
+            if not self._config.dense_search_enabled:
+                raise ConfigurationError("Dense search is disabled in configuration")
+            return await self.adense_search(
+                query_vector=query_vector,
+                top_k=top_k,
+                filter=filter,
+                similarity_threshold=similarity_threshold,
+                apply_reranking=apply_reranking,
+            )
+        elif has_text:
+            if not self._config.full_text_search_enabled:
+                raise ConfigurationError("Full-text search is disabled in configuration")
+            return await self.afull_text_search(
+                query_text=query_text,
+                top_k=top_k,
+                filter=filter,
+                similarity_threshold=similarity_threshold,
+                apply_reranking=apply_reranking,
+                sparse_query_vector=sparse_query_vector,
+            )
+        else:
+            raise ConfigurationError(
+                "Must provide either query_vector, query_text, or both"
+            )
+
+    async def adense_search(
+        self,
+        query_vector: List[float],
+        top_k: int,
+        filter: Optional[Dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+        apply_reranking: bool = True,
+    ) -> List[VectorSearchResult]:
+        """KNN vector similarity search using FT.SEARCH."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            # Build filter expression
+            filter_expr = self._build_filter_expression(filter) if filter else "*"
+
+            # KNN query: filter=>[KNN top_k @vector_field $query_vec]
+            query = (
+                f"({filter_expr})=>[KNN {top_k} "
+                f"@{self._config.vector_field_name} $query_vec]"
+            )
+
+            vector_bytes = self._vector_to_bytes(query_vector)
+            options = FtSearchOptions(
+                params={"query_vec": vector_bytes},
+                limit=FtSearchLimit(offset=0, count=top_k),
+            )
+
+            raw_results = await ft.search(
+                self.client, self._index_name, query, options
+            )
+
+            results = self._parse_search_results(raw_results, similarity_threshold)
+            logger.debug(f"Dense search returned {len(results)} results")
+            return results
+
+        except Exception as e:
+            if "no such index" in str(e).lower() or "unknown index" in str(e).lower():
+                raise CollectionDoesNotExistError(
+                    f"Index '{self._index_name}' does not exist"
+                ) from e
+            logger.error(f"Dense search failed: {e}")
+            raise SearchError(f"Dense search failed: {e}") from e
+
+    async def afull_text_search(
+        self,
+        query_text: str,
+        top_k: int,
+        filter: Optional[Dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+        apply_reranking: bool = True,
+        sparse_query_vector: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorSearchResult]:
+        """Full-text search using FT.SEARCH with text query."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            # Escape special characters in query text
+            escaped_text = self._escape_query_text(query_text)
+
+            # Build query with optional filter
+            if filter:
+                filter_expr = self._build_filter_expression(filter)
+                query = f"({filter_expr}) (@{self._config.text_field_name}:{escaped_text})"
+            else:
+                query = f"@{self._config.text_field_name}:{escaped_text}"
+
+            options = FtSearchOptions(
+                limit=FtSearchLimit(offset=0, count=top_k),
+            )
+
+            raw_results = await ft.search(
+                self.client, self._index_name, query, options
+            )
+
+            results = self._parse_search_results(raw_results, similarity_threshold)
+            logger.debug(f"Full-text search returned {len(results)} results")
+            return results
+
+        except Exception as e:
+            if "no such index" in str(e).lower() or "unknown index" in str(e).lower():
+                raise CollectionDoesNotExistError(
+                    f"Index '{self._index_name}' does not exist"
+                ) from e
+            logger.error(f"Full-text search failed: {e}")
+            raise SearchError(f"Full-text search failed: {e}") from e
+
+    async def ahybrid_search(
+        self,
+        query_vector: List[float],
+        query_text: str,
+        top_k: int,
+        filter: Optional[Dict[str, Any]] = None,
+        alpha: Optional[float] = None,
+        fusion_method: Optional[Literal['rrf', 'weighted']] = None,
+        similarity_threshold: Optional[float] = None,
+        apply_reranking: bool = True,
+        sparse_query_vector: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorSearchResult]:
+        """Hybrid search combining dense + full-text via RRF fusion."""
+        fusion_method = fusion_method or self._config.default_fusion_method
+
+        # Execute both searches with expanded top_k
+        expanded_k = top_k * 2
+
+        vector_results = await self.adense_search(
+            query_vector=query_vector,
+            top_k=expanded_k,
+            filter=filter,
+        )
+
+        text_results = await self.afull_text_search(
+            query_text=query_text,
+            top_k=expanded_k,
+            filter=filter,
+        )
+
+        # RRF fusion
+        k = self._config.rrf_k
+        vector_ranks: Dict[Any, int] = {r.id: i + 1 for i, r in enumerate(vector_results)}
+        text_ranks: Dict[Any, int] = {r.id: i + 1 for i, r in enumerate(text_results)}
+
+        rrf_scores: Dict[Any, float] = {}
+        all_ids = set(vector_ranks.keys()) | set(text_ranks.keys())
+
+        for doc_id in all_ids:
+            score = 0.0
+            if doc_id in vector_ranks:
+                score += 1.0 / (k + vector_ranks[doc_id])
+            if doc_id in text_ranks:
+                score += 1.0 / (k + text_ranks[doc_id])
+            rrf_scores[doc_id] = score
+
+        # Normalize scores to [0, 1]
+        if rrf_scores:
+            max_score = max(rrf_scores.values())
+            min_score = min(rrf_scores.values())
+            score_range = max_score - min_score
+            if score_range > 0:
+                rrf_scores = {
+                    did: (s - min_score) / score_range
+                    for did, s in rrf_scores.items()
+                }
+            else:
+                rrf_scores = {did: 1.0 for did in rrf_scores}
+
+        # Sort by score descending
+        sorted_ids = sorted(rrf_scores.keys(), key=lambda x: rrf_scores[x], reverse=True)
+
+        # Build result map
+        result_map: Dict[Any, VectorSearchResult] = {}
+        for r in vector_results + text_results:
+            if r.id not in result_map:
+                result_map[r.id] = r
+
+        results: List[VectorSearchResult] = []
+        for doc_id in sorted_ids[:top_k]:
+            result = result_map[doc_id]
+            results.append(VectorSearchResult(
+                id=result.id,
+                score=rrf_scores[doc_id],
+                payload=result.payload,
+                vector=result.vector,
+                text=result.text,
+            ))
+
+        if similarity_threshold is not None:
+            results = [r for r in results if r.score >= similarity_threshold]
+
+        logger.debug(f"Hybrid search (RRF) returned {len(results)} results")
+        return results
+
+    # ========================================================================
+    # Search Helpers
+    # ========================================================================
+
+    # Allowed TAG field names for filter expressions (security: prevents query injection)
+    _ALLOWED_FILTER_FIELDS = frozenset({
+        'chunk_id', 'document_id', 'document_name',
+        'doc_content_hash', 'chunk_content_hash', 'knowledge_base_id',
+    })
+
+    def _build_filter_expression(self, filter: Dict[str, Any]) -> str:
+        """Build a Valkey Search filter expression from a dict."""
+        clauses: List[str] = []
+        for key, value in filter.items():
+            if key.startswith("metadata."):
+                # Metadata fields are stored as JSON; can't filter directly
+                continue
+            if key not in self._ALLOWED_FILTER_FIELDS:
+                raise ValueError(f"Invalid filter field: {key!r}")
+            # TAG field filter: @field:{value}
+            # Escape all Valkey Search special characters in TAG values
+            escaped_val = self._escape_tag_value(str(value))
+            clauses.append(f"@{key}:{{{escaped_val}}}")
+
+        if not clauses:
+            return "*"
+        return " ".join(clauses)
+
+    @staticmethod
+    def _escape_tag_value(value: str) -> str:
+        """Escape special characters in a TAG field value for Valkey Search.
+
+        With separator='|' on TAG fields, most punctuation is safe.
+        Only Valkey Search query syntax characters need escaping.
+        """
+        # Characters that have special meaning in FT.SEARCH query syntax
+        special_chars = r'{}[]\\"|'
+        escaped = value
+        for char in special_chars:
+            escaped = escaped.replace(char, f"\\{char}")
+        return escaped
+
+    def _escape_query_text(self, text: str) -> str:
+        """Escape special characters for Valkey Search query syntax."""
+        # Valkey Search special chars that need escaping
+        special_chars = r',.<>{}[]"\'`:;!@#$%^&*()-+=~'
+        escaped = text
+        for char in special_chars:
+            escaped = escaped.replace(char, f"\\{char}")
+        # Wrap individual words for OR matching
+        words = escaped.split()
+        if len(words) > 1:
+            return " | ".join(words)
+        return escaped if escaped else "*"
+
+    def _parse_search_results(
+        self,
+        raw_results: Any,
+        similarity_threshold: Optional[float] = None,
+    ) -> List[VectorSearchResult]:
+        """Parse FT.SEARCH response into VectorSearchResult list."""
+        results: List[VectorSearchResult] = []
+
+        if not raw_results or not isinstance(raw_results, list):
+            return results
+
+        # FT.SEARCH returns: [total_count, {key: {field: value, ...}}, ...]
+        # In GLIDE format: [count, mapping_of_key_to_fields]
+        if len(raw_results) < 2:
+            return results
+
+        total_count = raw_results[0] if isinstance(raw_results[0], int) else 0
+        if total_count == 0:
+            return results
+
+        # The second element is a mapping of key -> fields
+        docs_map = raw_results[1] if len(raw_results) > 1 else {}
+
+        if not isinstance(docs_map, dict):
+            return results
+
+        for key, fields_data in docs_map.items():
+            key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
+
+            # Decode fields
+            fields: Dict[str, Any] = {}
+            if isinstance(fields_data, dict):
+                for fk, fv in fields_data.items():
+                    fk_str = fk.decode("utf-8") if isinstance(fk, bytes) else str(fk)
+                    if fk_str == self._config.vector_field_name:
+                        fields[fk_str] = fv  # Keep as bytes
+                    else:
+                        fields[fk_str] = fv.decode("utf-8") if isinstance(fv, bytes) else str(fv)
+
+            # Extract score from __vector_score or __score field
+            score_str = fields.pop("__vector_score", None) or fields.pop("__score", None)
+            if score_str is not None:
+                try:
+                    distance = float(score_str)
+                    score = self._distance_to_similarity(distance)
+                except (ValueError, TypeError):
+                    score = 0.0
+            else:
+                score = 1.0  # Full-text results without explicit score
+
+            if similarity_threshold is not None and score < similarity_threshold:
+                continue
+
+            # Extract vector if present
+            vector = None
+            vector_data = fields.get(self._config.vector_field_name)
+            if isinstance(vector_data, bytes):
+                vector = self._bytes_to_vector(vector_data)
+
+            chunk_id = fields.get("chunk_id", "")
+            if not chunk_id:
+                # Extract from key: remove prefix
+                chunk_id = key_str.removeprefix(self._key_prefix)
+
+            results.append(VectorSearchResult(
+                id=chunk_id,
+                score=score,
+                payload=self._fields_to_payload(fields),
+                vector=vector,
+                text=fields.get(self._config.text_field_name, ""),
+            ))
+
+        return results
+
+    # ========================================================================
+    # Existence Checks
+    # ========================================================================
+
+    async def _field_exists(self, field_name: str, field_value: str) -> bool:
+        """Check if any record with the given TAG field value exists."""
+        if self.client is None:
+            return False
+        try:
+            escaped_val = self._escape_tag_value(field_value)
+            query = f"@{field_name}:{{{escaped_val}}}"
+            options = FtSearchOptions(limit=FtSearchLimit(offset=0, count=0))
+            raw = await ft.search(self.client, self._index_name, query, options)
+            if raw and isinstance(raw, list) and len(raw) > 0:
+                count = raw[0] if isinstance(raw[0], int) else 0
+                return count > 0
+            return False
+        except Exception:
+            return False
+
+    async def adocument_id_exists(self, document_id: str) -> bool:
+        return await self._field_exists("document_id", document_id)
+
+    async def adocument_name_exists(self, document_name: str) -> bool:
+        return await self._field_exists("document_name", document_name)
+
+    async def achunk_id_exists(self, chunk_id: str) -> bool:
+        return await self._field_exists("chunk_id", chunk_id)
+
+    async def adoc_content_hash_exists(self, doc_content_hash: str) -> bool:
+        return await self._field_exists("doc_content_hash", doc_content_hash)
+
+    async def achunk_content_hash_exists(self, chunk_content_hash: str) -> bool:
+        return await self._field_exists("chunk_content_hash", chunk_content_hash)
+
+    # ========================================================================
+    # Delete by Field
+    # ========================================================================
+
+    async def _delete_by_field(self, field_name: str, field_value: str) -> bool:
+        """Find and delete all records matching a TAG field value."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            escaped_val = self._escape_tag_value(field_value)
+            query = f"@{field_name}:{{{escaped_val}}}"
+            # Fetch matching keys (up to 10000)
+            options = FtSearchOptions(limit=FtSearchLimit(offset=0, count=10000))
+            raw = await ft.search(self.client, self._index_name, query, options)
+
+            if not raw or not isinstance(raw, list) or len(raw) < 2:
+                return True  # Nothing to delete
+
+            count = raw[0] if isinstance(raw[0], int) else 0
+            if count == 0:
+                return True
+
+            docs_map = raw[1] if len(raw) > 1 else {}
+            if isinstance(docs_map, dict):
+                keys_to_delete = [
+                    key.decode("utf-8") if isinstance(key, bytes) else str(key)
+                    for key in docs_map.keys()
+                ]
+                if keys_to_delete:
+                    await self.client.unlink(keys_to_delete)
+
+            logger.info(f"Deleted records with {field_name}='{field_value}'")
+            return True
+
+        except Exception as e:
+            logger.error(f"Delete by {field_name} failed: {e}")
+            return False
+
+    async def adelete_by_document_name(self, document_name: str) -> bool:
+        return await self._delete_by_field("document_name", document_name)
+
+    async def adelete_by_document_id(self, document_id: str) -> bool:
+        return await self._delete_by_field("document_id", document_id)
+
+    async def adelete_by_chunk_id(self, chunk_id: str) -> bool:
+        return await self._delete_by_field("chunk_id", chunk_id)
+
+    async def adelete_by_doc_content_hash(self, doc_content_hash: str) -> bool:
+        return await self._delete_by_field("doc_content_hash", doc_content_hash)
+
+    async def adelete_by_chunk_content_hash(self, chunk_content_hash: str) -> bool:
+        return await self._delete_by_field("chunk_content_hash", chunk_content_hash)
+
+    async def adelete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        """Delete by metadata — uses TAG field filters where possible."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            filter_expr = self._build_filter_expression(metadata)
+            if filter_expr == "*":
+                logger.warning("Cannot delete by metadata: no filterable fields")
+                return False
+
+            options = FtSearchOptions(limit=FtSearchLimit(offset=0, count=10000))
+            raw = await ft.search(self.client, self._index_name, filter_expr, options)
+
+            if not raw or not isinstance(raw, list) or len(raw) < 2:
+                return True
+
+            docs_map = raw[1] if len(raw) > 1 else {}
+            if isinstance(docs_map, dict):
+                keys_to_delete = [
+                    key.decode("utf-8") if isinstance(key, bytes) else str(key)
+                    for key in docs_map.keys()
+                ]
+                if keys_to_delete:
+                    await self.client.unlink(keys_to_delete)
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Delete by metadata failed: {e}")
+            return False
+
+    # ========================================================================
+    # Update Metadata
+    # ========================================================================
+
+    async def aupdate_metadata(self, chunk_id: str, metadata: Dict[str, Any]) -> bool:
+        """Update metadata for a record identified by chunk_id."""
+        if self.client is None:
+            raise VectorDBConnectionError("Not connected to Valkey")
+
+        try:
+            key = self._make_key(chunk_id)
+            # Read existing metadata
+            existing = await self.client.hget(key, "metadata")
+            if existing is None:
+                logger.warning(f"Record with chunk_id '{chunk_id}' not found")
+                return False
+
+            existing_str = existing.decode("utf-8") if isinstance(existing, bytes) else str(existing)
+            try:
+                current_meta = json.loads(existing_str)
+            except (json.JSONDecodeError, TypeError):
+                current_meta = {}
+
+            # Merge
+            current_meta.update(metadata)
+            await self.client.hset(key, {"metadata": json.dumps(current_meta)})
+            logger.info(f"Updated metadata for chunk_id '{chunk_id}'")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to update metadata: {e}")
+            return False
+
+    # ========================================================================
+    # Optimize
+    # ========================================================================
+
+    async def aoptimize(self) -> bool:
+        """Optimization is handled automatically by Valkey Search. No-op."""
+        logger.info("Valkey Search handles index optimization automatically.")
+        return True
+
+    # ========================================================================
+    # Supported Search Types
+    # ========================================================================
+
+    async def aget_supported_search_types(self) -> List[str]:
+        supported: List[str] = []
+        if self._config.dense_search_enabled:
+            supported.append("dense")
+        if self._config.full_text_search_enabled:
+            supported.append("full_text")
+        if self._config.hybrid_search_enabled:
+            supported.append("hybrid")
+        return supported
+
+    # ========================================================================
+    # Repr
+    # ========================================================================
+
+    def __repr__(self) -> str:
+        return (
+            f"ValkeyProvider(index='{self._index_name}', "
+            f"vector_size={self._config.vector_size}, "
+            f"metric={self._config.distance_metric.value}, "
+            f"algorithm={'HNSW' if isinstance(self._config.index, HNSWIndexConfig) else 'FLAT'})"
+        )

--- a/src/upsonic/vectordb/providers/valkey.py
+++ b/src/upsonic/vectordb/providers/valkey.py
@@ -230,7 +230,10 @@ class ValkeyProvider(BaseVectorDBProvider):
             else:
                 addresses.append(NodeAddress("localhost", 6379))
 
-            kwargs: Dict[str, Any] = {"addresses": addresses}
+            kwargs: Dict[str, Any] = {
+                "addresses": addresses,
+                "client_name": "upsonic_vector_store_client",
+            }
             if self._config.request_timeout is not None:
                 kwargs["request_timeout"] = self._config.request_timeout
 

--- a/tests/doc_examples/vectordb/valkey_basic.py
+++ b/tests/doc_examples/vectordb/valkey_basic.py
@@ -1,0 +1,110 @@
+"""
+Basic usage of ValkeyProvider for vector storage and search.
+
+Requirements:
+- Valkey 9.1+ with valkey-search module loaded
+- pip install "upsonic[valkey]"
+"""
+
+import asyncio
+from upsonic.vectordb import ValkeyProvider, ValkeyConfig
+from upsonic.vectordb.config import (
+    ConnectionConfig,
+    Mode,
+    DistanceMetric,
+    HNSWIndexConfig,
+)
+
+
+async def main():
+    # Configure the provider
+    config = ValkeyConfig(
+        vector_size=384,  # Match your embedding model's dimension
+        collection_name="my_documents",
+        key_prefix="docs:",
+        connection=ConnectionConfig(
+            mode=Mode.LOCAL,
+            host="localhost",
+            port=6379,
+        ),
+        distance_metric=DistanceMetric.COSINE,
+        index=HNSWIndexConfig(m=16, ef_construction=200),
+    )
+
+    # Create provider and connect
+    provider = ValkeyProvider(config)
+    await provider.aconnect()
+
+    # Create the search index
+    await provider.acreate_collection()
+
+    # Upsert documents (vectors would come from your embedding provider)
+    await provider.aupsert(
+        vectors=[
+            [0.1] * 384,  # Replace with real embeddings
+            [0.2] * 384,
+            [0.3] * 384,
+        ],
+        ids=["chunk_1", "chunk_2", "chunk_3"],
+        chunks=[
+            "Valkey is a high-performance in-memory data store",
+            "Vector search enables semantic similarity matching",
+            "HNSW provides fast approximate nearest neighbor search",
+        ],
+        document_ids=["doc_1", "doc_1", "doc_2"],
+        document_names=["valkey_intro.md", "valkey_intro.md", "vector_search.md"],
+    )
+
+    # Brief pause to allow the index to process ingested data
+    await asyncio.sleep(0.5)
+
+    # Dense (KNN) vector search
+    query_vector = [0.15] * 384  # Replace with embedded query
+    results = await provider.adense_search(
+        query_vector=query_vector,
+        top_k=2,
+    )
+    print("Dense search results:")
+    for r in results:
+        print(f"  [{r.score:.3f}] {r.text[:60]}...")
+
+    # Full-text search
+    results = await provider.afull_text_search(
+        query_text="vector similarity",
+        top_k=2,
+    )
+    print("\nFull-text search results:")
+    for r in results:
+        print(f"  [{r.score:.3f}] {r.text[:60]}...")
+
+    # Hybrid search (combines vector + text via RRF)
+    results = await provider.ahybrid_search(
+        query_vector=query_vector,
+        query_text="nearest neighbor",
+        top_k=2,
+    )
+    print("\nHybrid search results:")
+    for r in results:
+        print(f"  [{r.score:.3f}] {r.text[:60]}...")
+
+    # Search with filter
+    results = await provider.adense_search(
+        query_vector=query_vector,
+        top_k=5,
+        filter={"document_name": "valkey_intro.md"},
+    )
+    print("\nFiltered search (valkey_intro.md only):")
+    for r in results:
+        print(f"  [{r.score:.3f}] {r.text[:60]}...")
+
+    # Check existence
+    exists = await provider.achunk_content_hash_exists("some_hash")
+    print(f"\nChunk exists: {exists}")
+
+    # Cleanup
+    await provider.adelete_collection()
+    await provider.adisconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/doc_examples/vectordb/valkey_sync.py
+++ b/tests/doc_examples/vectordb/valkey_sync.py
@@ -1,0 +1,49 @@
+"""
+Synchronous usage of ValkeyProvider.
+
+The sync API is provided automatically by the base class — no extra
+implementation needed. Useful for scripts and notebooks.
+
+Requirements:
+- Valkey 9.1+ with valkey-search module loaded
+- pip install "upsonic[valkey]"
+"""
+
+from upsonic.vectordb import ValkeyProvider, ValkeyConfig
+from upsonic.vectordb.config import ConnectionConfig, Mode, DistanceMetric
+
+
+# Configure and connect (sync)
+config = ValkeyConfig(
+    vector_size=128,
+    collection_name="sync_example",
+    key_prefix="sync:",
+    connection=ConnectionConfig(mode=Mode.LOCAL, host="localhost", port=6379),
+    distance_metric=DistanceMetric.COSINE,
+)
+
+provider = ValkeyProvider(config)
+provider.connect()
+provider.create_collection()
+
+# Upsert
+provider.upsert(
+    vectors=[[0.1] * 128, [0.9] * 128],
+    ids=["a", "b"],
+    chunks=["First document about AI", "Second document about databases"],
+)
+
+# Search
+import time
+time.sleep(0.3)  # Allow index to update
+
+results = provider.search(
+    query_vector=[0.1] * 128,
+    top_k=2,
+)
+for r in results:
+    print(f"[{r.score:.3f}] {r.id}: {r.text}")
+
+# Cleanup
+provider.delete_collection()
+provider.disconnect()

--- a/tests/smoke_tests/vectordb/test_valkey_provider.py
+++ b/tests/smoke_tests/vectordb/test_valkey_provider.py
@@ -1,0 +1,551 @@
+"""
+Comprehensive smoke tests for Valkey Search vector database provider.
+
+Tests all methods, attributes, and search modes against a real Valkey 9.1+
+instance with the valkey-search module loaded.
+
+Requirements:
+- Valkey 9.1+ running on localhost:6379
+- valkey-search module loaded (v1.2+)
+- valkey-glide>=2.3.1 installed
+"""
+
+import os
+import pytest
+import asyncio
+from typing import List, Dict, Any
+
+from upsonic.vectordb.providers.valkey import ValkeyProvider
+from upsonic.vectordb.config import (
+    ValkeyConfig,
+    ConnectionConfig,
+    Mode,
+    DistanceMetric,
+    HNSWIndexConfig,
+    FlatIndexConfig,
+)
+from upsonic.utils.package.exception import (
+    VectorDBConnectionError,
+    ConfigurationError,
+    CollectionDoesNotExistError,
+    VectorDBError,
+    SearchError,
+    UpsertError,
+)
+from upsonic.schemas.vector_schemas import VectorSearchResult
+
+
+# Test data
+SAMPLE_VECTORS: List[List[float]] = [
+    [0.1, 0.2, 0.3, 0.4, 0.5],
+    [0.6, 0.7, 0.8, 0.9, 1.0],
+    [1.1, 1.2, 1.3, 1.4, 1.5],
+    [1.6, 1.7, 1.8, 1.9, 2.0],
+    [2.1, 2.2, 2.3, 2.4, 2.5],
+]
+
+SAMPLE_PAYLOADS: List[Dict[str, Any]] = [
+    {"category": "science", "author": "Einstein", "year": 1905},
+    {"category": "science", "author": "Newton", "year": 1687},
+    {"category": "literature", "author": "Shakespeare", "year": 1600},
+    {"category": "literature", "author": "Dickens", "year": 1850},
+    {"category": "philosophy", "author": "Plato", "year": -400},
+]
+
+SAMPLE_CHUNKS: List[str] = [
+    "The theory of relativity revolutionized physics",
+    "Laws of motion and universal gravitation",
+    "To be or not to be that is the question",
+    "It was the best of times it was the worst of times",
+    "The unexamined life is not worth living",
+]
+
+SAMPLE_IDS: List[str] = [
+    "chunk_aaa111",
+    "chunk_bbb222",
+    "chunk_ccc333",
+    "chunk_ddd444",
+    "chunk_eee555",
+]
+
+QUERY_VECTOR: List[float] = [0.15, 0.25, 0.35, 0.45, 0.55]
+QUERY_TEXT: str = "physics theory"
+
+VALKEY_HOST = os.getenv("VALKEY_HOST", "localhost")
+VALKEY_PORT = int(os.getenv("VALKEY_PORT", "6379"))
+
+
+def _can_connect_to_valkey() -> bool:
+    """Check if Valkey is reachable."""
+    import socket
+    try:
+        s = socket.create_connection((VALKEY_HOST, VALKEY_PORT), timeout=2)
+        s.close()
+        return True
+    except (socket.error, OSError):
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _can_connect_to_valkey(),
+        reason=f"Valkey not available at {VALKEY_HOST}:{VALKEY_PORT}",
+    ),
+]
+
+
+class TestValkeyProvider:
+    """Test ValkeyProvider against a real Valkey instance."""
+
+    @pytest.fixture
+    def config(self) -> ValkeyConfig:
+        """Create ValkeyConfig with unique collection name."""
+        import uuid
+        unique_name = f"test_valkey_{uuid.uuid4().hex[:8]}"
+        return ValkeyConfig(
+            vector_size=5,
+            collection_name=unique_name,
+            key_prefix=f"{unique_name}:",
+            connection=ConnectionConfig(
+                mode=Mode.LOCAL,
+                host=VALKEY_HOST,
+                port=VALKEY_PORT,
+            ),
+            distance_metric=DistanceMetric.COSINE,
+            index=HNSWIndexConfig(m=16, ef_construction=200),
+        )
+
+    @pytest.fixture
+    def provider(self, config: ValkeyConfig) -> ValkeyProvider:
+        """Create ValkeyProvider instance."""
+        return ValkeyProvider(config)
+
+    @pytest.mark.asyncio
+    async def test_initialization(self, provider: ValkeyProvider, config: ValkeyConfig):
+        """Test provider initialization and attributes."""
+        assert provider._config == config
+        assert provider._config.vector_size == 5
+        assert provider._config.distance_metric == DistanceMetric.COSINE
+        assert not provider._is_connected
+        assert provider.client is None
+        assert provider.name is not None
+        assert isinstance(provider.id, str)
+        assert len(provider.id) > 0
+
+    @pytest.mark.asyncio
+    async def test_connect(self, provider: ValkeyProvider):
+        """Test connection to Valkey."""
+        await provider.aconnect()
+        assert provider._is_connected
+        assert provider.client is not None
+        assert await provider.ais_ready()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_sync(self, provider: ValkeyProvider):
+        """Test synchronous connection."""
+        provider.connect()
+        assert provider._is_connected
+        assert provider.client is not None
+        assert provider.is_ready()
+        provider.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, provider: ValkeyProvider):
+        """Test disconnection."""
+        await provider.aconnect()
+        assert provider._is_connected
+        await provider.adisconnect()
+        assert not provider._is_connected
+
+    @pytest.mark.asyncio
+    async def test_is_ready(self, provider: ValkeyProvider):
+        """Test is_ready check."""
+        assert not await provider.ais_ready()
+        await provider.aconnect()
+        assert await provider.ais_ready()
+        await provider.adisconnect()
+        assert not await provider.ais_ready()
+
+    @pytest.mark.asyncio
+    async def test_create_collection(self, provider: ValkeyProvider):
+        """Test index creation."""
+        await provider.aconnect()
+        assert not await provider.acollection_exists()
+        await provider.acreate_collection()
+        assert await provider.acollection_exists()
+        # Cleanup
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_create_collection_sync(self, provider: ValkeyProvider):
+        """Test synchronous index creation."""
+        provider.connect()
+        assert not provider.collection_exists()
+        provider.create_collection()
+        assert provider.collection_exists()
+        provider.delete_collection()
+        provider.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_collection(self, provider: ValkeyProvider):
+        """Test index deletion."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        assert await provider.acollection_exists()
+        await provider.adelete_collection()
+        assert not await provider.acollection_exists()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_collection(self, provider: ValkeyProvider):
+        """Test deleting non-existent index raises error."""
+        await provider.aconnect()
+        with pytest.raises((CollectionDoesNotExistError, VectorDBError)):
+            await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_fetch(self, provider: ValkeyProvider):
+        """Test upsert and fetch operations."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+
+        # Fetch by IDs
+        results = await provider.afetch(ids=SAMPLE_IDS[:2])
+        assert len(results) == 2
+        assert all(isinstance(r, VectorSearchResult) for r in results)
+
+        # Verify content
+        for result in results:
+            assert result.id in SAMPLE_IDS[:2]
+            assert result.text in SAMPLE_CHUNKS[:2]
+            assert result.vector is not None
+            assert len(result.vector) == 5
+            assert result.payload is not None
+
+        # Cleanup
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_upsert_sync(self, provider: ValkeyProvider):
+        """Test synchronous upsert."""
+        provider.connect()
+        provider.create_collection()
+        provider.upsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+        results = provider.fetch(ids=SAMPLE_IDS[:1])
+        assert len(results) == 1
+        provider.delete_collection()
+        provider.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_upsert_with_document_tracking(self, provider: ValkeyProvider):
+        """Test upsert with document_name, document_id, and hashes."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS[:2],
+            payloads=SAMPLE_PAYLOADS[:2],
+            ids=SAMPLE_IDS[:2],
+            chunks=SAMPLE_CHUNKS[:2],
+            document_ids=["doc_id_1", "doc_id_2"],
+            document_names=["doc_alpha", "doc_beta"],
+        )
+
+        results = await provider.afetch(ids=SAMPLE_IDS[:2])
+        assert len(results) == 2
+        for result in results:
+            assert result.payload["document_id"] in ["doc_id_1", "doc_id_2"]
+            assert result.payload["document_name"] in ["doc_alpha", "doc_beta"]
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_upsert_validation_error(self, provider: ValkeyProvider):
+        """Test upsert with mismatched lengths raises ValueError."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        with pytest.raises(ValueError):
+            await provider.aupsert(
+                vectors=SAMPLE_VECTORS[:2],
+                payloads=SAMPLE_PAYLOADS[:3],
+                ids=SAMPLE_IDS[:2],
+                chunks=SAMPLE_CHUNKS[:2],
+            )
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete(self, provider: ValkeyProvider):
+        """Test delete operation."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+        await provider.adelete(ids=SAMPLE_IDS[:2])
+        results = await provider.afetch(ids=SAMPLE_IDS[:2])
+        assert len(results) == 0
+        # Remaining records still exist
+        results = await provider.afetch(ids=SAMPLE_IDS[2:])
+        assert len(results) == 3
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_dense_search(self, provider: ValkeyProvider):
+        """Test KNN vector similarity search."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+
+        # Allow index to update
+        await asyncio.sleep(0.5)
+
+        results = await provider.adense_search(
+            query_vector=QUERY_VECTOR,
+            top_k=3,
+        )
+        assert len(results) > 0
+        assert len(results) <= 3
+        assert all(isinstance(r, VectorSearchResult) for r in results)
+        # Results should be sorted by score descending
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+        # First result should be closest to query vector (which is near SAMPLE_VECTORS[0])
+        assert results[0].id == SAMPLE_IDS[0]
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_dense_search_with_filter(self, provider: ValkeyProvider):
+        """Test dense search with TAG filter."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+            document_names=["science_doc"] * 2 + ["literature_doc"] * 2 + ["philosophy_doc"],
+        )
+
+        await asyncio.sleep(0.5)
+
+        results = await provider.adense_search(
+            query_vector=QUERY_VECTOR,
+            top_k=5,
+            filter={"document_name": "science_doc"},
+        )
+        # Should only return science docs
+        assert len(results) <= 2
+        for r in results:
+            assert r.payload["document_name"] == "science_doc"
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_full_text_search(self, provider: ValkeyProvider):
+        """Test full-text search."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+
+        await asyncio.sleep(0.5)
+
+        results = await provider.afull_text_search(
+            query_text="relativity physics",
+            top_k=3,
+        )
+        assert len(results) > 0
+        # The first chunk mentions "relativity" and "physics"
+        found_texts = [r.text for r in results]
+        assert any("relativity" in t for t in found_texts)
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search(self, provider: ValkeyProvider):
+        """Test hybrid search combining vector + text."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS,
+            payloads=SAMPLE_PAYLOADS,
+            ids=SAMPLE_IDS,
+            chunks=SAMPLE_CHUNKS,
+        )
+
+        await asyncio.sleep(0.5)
+
+        results = await provider.ahybrid_search(
+            query_vector=QUERY_VECTOR,
+            query_text="physics theory",
+            top_k=3,
+        )
+        assert len(results) > 0
+        assert len(results) <= 3
+        # Scores should be normalized [0, 1]
+        for r in results:
+            assert 0.0 <= r.score <= 1.0
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_existence_checks(self, provider: ValkeyProvider):
+        """Test existence check methods."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS[:1],
+            payloads=SAMPLE_PAYLOADS[:1],
+            ids=SAMPLE_IDS[:1],
+            chunks=SAMPLE_CHUNKS[:1],
+            document_ids=["doc_id_1"],
+            document_names=["test_doc"],
+            chunk_content_hashes=["hash_abc123"],
+        )
+
+        await asyncio.sleep(0.5)
+
+        assert await provider.achunk_id_exists(SAMPLE_IDS[0])
+        assert not await provider.achunk_id_exists("nonexistent")
+
+        assert await provider.adocument_name_exists("test_doc")
+        assert not await provider.adocument_name_exists("nonexistent")
+
+        assert await provider.adocument_id_exists("doc_id_1")
+        assert not await provider.adocument_id_exists("nonexistent")
+
+        assert await provider.achunk_content_hash_exists("hash_abc123")
+        assert not await provider.achunk_content_hash_exists("nonexistent")
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_by_document_name(self, provider: ValkeyProvider):
+        """Test delete_by_document_name."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS[:2],
+            payloads=SAMPLE_PAYLOADS[:2],
+            ids=SAMPLE_IDS[:2],
+            chunks=SAMPLE_CHUNKS[:2],
+            document_names=["target_doc", "target_doc"],
+        )
+
+        await asyncio.sleep(0.5)
+
+        deleted = await provider.adelete_by_document_name("target_doc")
+        assert deleted is True
+
+        # Verify they're gone
+        results = await provider.afetch(ids=SAMPLE_IDS[:2])
+        assert len(results) == 0
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_delete_by_document_id(self, provider: ValkeyProvider):
+        """Test delete_by_document_id."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS[:2],
+            payloads=SAMPLE_PAYLOADS[:2],
+            ids=SAMPLE_IDS[:2],
+            chunks=SAMPLE_CHUNKS[:2],
+            document_ids=["doc_to_delete", "doc_to_delete"],
+        )
+
+        await asyncio.sleep(0.5)
+
+        deleted = await provider.adelete_by_document_id("doc_to_delete")
+        assert deleted is True
+
+        results = await provider.afetch(ids=SAMPLE_IDS[:2])
+        assert len(results) == 0
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_update_metadata(self, provider: ValkeyProvider):
+        """Test metadata update."""
+        await provider.aconnect()
+        await provider.acreate_collection()
+        await provider.aupsert(
+            vectors=SAMPLE_VECTORS[:1],
+            payloads=[{"initial_key": "initial_value"}],
+            ids=SAMPLE_IDS[:1],
+            chunks=SAMPLE_CHUNKS[:1],
+        )
+
+        success = await provider.aupdate_metadata(
+            SAMPLE_IDS[0], {"new_key": "new_value"}
+        )
+        assert success is True
+
+        # Verify
+        results = await provider.afetch(ids=SAMPLE_IDS[:1])
+        assert len(results) == 1
+        meta = results[0].payload.get("metadata", {})
+        assert meta.get("new_key") == "new_value"
+        assert meta.get("initial_key") == "initial_value"
+
+        await provider.adelete_collection()
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_supported_search_types(self, provider: ValkeyProvider):
+        """Test get_supported_search_types."""
+        await provider.aconnect()
+        types = await provider.aget_supported_search_types()
+        assert "dense" in types
+        assert "full_text" in types
+        assert "hybrid" in types
+        await provider.adisconnect()
+
+    @pytest.mark.asyncio
+    async def test_optimize(self, provider: ValkeyProvider):
+        """Test optimize (no-op for Valkey)."""
+        await provider.aconnect()
+        result = await provider.aoptimize()
+        assert result is True
+        await provider.adisconnect()

--- a/uv.lock
+++ b/uv.lock
@@ -3550,7 +3550,7 @@ wheels = [
 
 [[package]]
 name = "mem0ai"
-version = "1.0.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "openai" },
@@ -3561,9 +3561,9 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/cd/f9047cd45952af08da8084c2297f8aad780f9ac8558631fc64b3ed235b28/mem0ai-1.0.1.tar.gz", hash = "sha256:53be77f479387e6c07508096eb6c0688150b31152613bdcf6c281246b000b14d", size = 182296, upload-time = "2025-11-13T22:32:13.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/8f/86975bdf11a0aece78b6f4d5551b8b92c38b9bdf5f5764fc879e6cb1227b/mem0ai-2.0.2.tar.gz", hash = "sha256:482d11a55c8aa00dce29a66eeecbba2fd5f5c7501c054ce8ba606baee3755f99", size = 214627, upload-time = "2026-05-07T20:03:47.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/42/120d6db33e190ef09d69428ddd2eaaa87e10f4c8243af788f5fc524748c9/mem0ai-1.0.1-py3-none-any.whl", hash = "sha256:a8eeca9688e87f175af53d463b4a3b2d552984c81e29bc656c847dc04eaf6f75", size = 275351, upload-time = "2025-11-13T22:32:11.839Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f8/59902456c1950e63b6b226634463bc8b24d81697e7114f0740059fd0a270/mem0ai-2.0.2-py3-none-any.whl", hash = "sha256:6fda32549c213fb63b393f4b1920f54961ea75c51d95b6492096108609accf3b", size = 302276, upload-time = "2026-05-07T20:03:45.706Z" },
 ]
 
 [[package]]
@@ -5417,16 +5417,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "5.29.5"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz", hash = "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84", size = 425226, upload-time = "2025-05-28T23:51:59.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/11/6e40e9fc5bba02988a214c07cf324595789ca7820160bfd1f8be96e48539/protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079", size = 422963, upload-time = "2025-05-28T23:51:41.204Z" },
-    { url = "https://files.pythonhosted.org/packages/81/7f/73cefb093e1a2a7c3ffd839e6f9fcafb7a427d300c7f8aef9c64405d8ac6/protobuf-5.29.5-cp310-abi3-win_amd64.whl", hash = "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc", size = 434818, upload-time = "2025-05-28T23:51:44.297Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091, upload-time = "2025-05-28T23:51:45.907Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
-    { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -9081,6 +9082,9 @@ tools = [
     { name = "tavily-python" },
     { name = "yfinance" },
 ]
+valkey = [
+    { name = "valkey-glide" },
+]
 vectordb = [
     { name = "chromadb", marker = "python_full_version < '3.14'" },
     { name = "faiss-cpu" },
@@ -9097,6 +9101,7 @@ vectordb = [
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "sqlalchemy" },
     { name = "supermemory" },
+    { name = "valkey-glide" },
     { name = "weaviate-client" },
 ]
 weaviate = [
@@ -9236,7 +9241,7 @@ requires-dist = [
     { name = "pinecone", marker = "extra == 'vectordb'", specifier = ">=7.3.0" },
     { name = "pinecone-text", marker = "python_full_version < '3.14' and extra == 'pinecone'", specifier = ">=0.11.0" },
     { name = "pinecone-text", marker = "python_full_version < '3.14' and extra == 'vectordb'", specifier = ">=0.11.0" },
-    { name = "protobuf", specifier = ">=5.27.2,<6.0.0" },
+    { name = "protobuf", specifier = ">=5.27.2,<7.0.0" },
     { name = "psutil", specifier = "==6.1.1" },
     { name = "psycopg", marker = "extra == 'pgvector'", specifier = ">=3.2.9" },
     { name = "psycopg", marker = "extra == 'vectordb'", specifier = ">=3.2.9" },
@@ -9299,13 +9304,15 @@ requires-dist = [
     { name = "upsonic", extras = ["sqlite-storage"], marker = "extra == 'storage'" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.35.0" },
+    { name = "valkey-glide", marker = "extra == 'valkey'", specifier = ">=2.3.1" },
+    { name = "valkey-glide", marker = "extra == 'vectordb'", specifier = ">=2.3.1" },
     { name = "weaviate-client", marker = "extra == 'vectordb'", specifier = ">=4.16.9" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.16.9" },
     { name = "websockets", marker = "extra == 'discord-interface'", specifier = ">=12.0" },
     { name = "xai-sdk", marker = "extra == 'models'", specifier = ">=1.4.0" },
     { name = "yfinance", marker = "extra == 'tools'", specifier = ">=0.2.66" },
 ]
-provides-extras = ["mcp", "asqav", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
+provides-extras = ["mcp", "asqav", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "valkey", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -9438,6 +9445,48 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
+name = "valkey-glide"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "protobuf" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/04/92be56c4dd9b5c89f10999e66f4d0e156d07d7b45aed9b0f89273f26aac5/valkey_glide-2.3.1.tar.gz", hash = "sha256:f4bae030c0aa6e55edb2c27dbd55f82cfb5f581904fff1318eec1c062f30d4b3", size = 832671, upload-time = "2026-04-01T17:56:32.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/40/b2ea2da3baa3085cfa93740a431e1054ff2f9c95a23c476618f7859b2083/valkey_glide-2.3.1-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:736a3e58393fa4f0f2fbb10031d46da5f18ebb8e72d2f9428ff24f0f6addeb3f", size = 7379323, upload-time = "2026-04-01T17:55:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ef/ad098d9c8c4385cedb66344316eaba7d8ca613c87dd757ca4f56390f11b9/valkey_glide-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2cd6f5c4e9b67b78873f34f19b9182bab5b07a9151855cf059303e05dac3b2f", size = 6860556, upload-time = "2026-04-01T17:55:28.255Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/14/680b98b22e0af970758a9fe7e16f1f438a0424c6761820e8d5732f6220ea/valkey_glide-2.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ddf70bc7888d565273e4bf858ff6047d5284140ff380a732f807c775be8e108", size = 7133576, upload-time = "2026-04-01T17:55:29.778Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a8/4683c403fe26aa9cecc25e557e924f64ea9185c45b31c17aeecd89e00a5f/valkey_glide-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f947dd44ba9741eadcab154443f447c19f23dab56de33f56d5f133ee0d597c2", size = 7599098, upload-time = "2026-04-01T17:55:31.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/19/4cce4fde822f2fa0df7c98e82232af367471996efe89d2c680022350a618/valkey_glide-2.3.1-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:6ddc4c6bee1a9c102f003cddc5d1bad8173a9d90e1c9a0f73a285228ed8625af", size = 7378844, upload-time = "2026-04-01T17:55:33.321Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/04/fca4862a885e0f0ef9560f2d4e42f29e0ec6df27e487aa64dc9c0b9a2f6e/valkey_glide-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30590532136e4ea38b6a6389cbcfe4edc554418563c6e4f6357b0749907b2c20", size = 6860870, upload-time = "2026-04-01T17:55:34.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/7eb28e04008e247c2fe5c427b3dbbd81b238dd8ed9772e2acfc999008e42/valkey_glide-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bbdb7baa7aac12c109aefd97f69f9780a4812429db18786254ef288ecf75f19", size = 7135059, upload-time = "2026-04-01T17:55:36.63Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/81/cbb2bfb989efef22b43b66a7e8249aa4afbb1201c2e9a29bb32677460ee9/valkey_glide-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd64d77ae26efd524be58456e22636ce4cb0a6110ad722e89f249a45d098692", size = 7596374, upload-time = "2026-04-01T17:55:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/04/9c492cdf0238aabd2902f4f252dd63ffee64cd0228d06989c8cd2a272291/valkey_glide-2.3.1-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:406b73f5ee080406fbfeda542d37de7e330fb4d83b0aa7212b92707d7b7b82a6", size = 7381382, upload-time = "2026-04-01T17:55:40.431Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ab/15302dba094927acced9bfccdbe5cf333129ddedf5e8378b94b415a54ccd/valkey_glide-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0940d4069cbc4896dec3a1ab39db7bf86667fb32892df4dbf3b043129d26d6e5", size = 6854103, upload-time = "2026-04-01T17:55:42.166Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/54/6b40a104352e44b36558528cd97d1ec7c12585b1fa1019b1794d52d19ab5/valkey_glide-2.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b47de0ec3d5a253c2b37d33266aaeb22503014f9e8f0611ba999e06f9804966a", size = 7134311, upload-time = "2026-04-01T17:55:43.966Z" },
+    { url = "https://files.pythonhosted.org/packages/97/79/84de88074bc6780813415afd704e9c827be13b3aa02cc5508122070ae100/valkey_glide-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a364210002dd0e7c3362299f61a2a1cacf867594a8a0bbf157a345f3f40d4d94", size = 7597689, upload-time = "2026-04-01T17:55:45.898Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/bd/1cdb584687a2d2cd762a53cf111932aee1216186a6b28d00724805679643/valkey_glide-2.3.1-cp313-cp313-macosx_10_7_x86_64.whl", hash = "sha256:86d56756842acd6286601128822c5f1f9dcd61305f0c6a80c3e7fb3a7e0404ef", size = 7384605, upload-time = "2026-04-01T17:55:47.94Z" },
+    { url = "https://files.pythonhosted.org/packages/85/76/f8c609597a24a07957c1d0e13d6f083376ad12ee205b21414d6a445c51fa/valkey_glide-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b307795a23473b8e7cff781eb54936cc672a430820f5fa71c6b6fb3748cc1189", size = 6854336, upload-time = "2026-04-01T17:55:50.079Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5e/4fc465f880219712c9daff2b38a55008515946dfa5b3b63d3232b75c6bf4/valkey_glide-2.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cb570f5d637ee55300ccdecd39a51cbf25c67ab6e25f2022d42f32a7bec6163", size = 7134155, upload-time = "2026-04-01T17:55:51.566Z" },
+    { url = "https://files.pythonhosted.org/packages/00/46/894470eaf297a5d302b63c0900722fa56715a53ccd577528978171481553/valkey_glide-2.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:506c7800eec05caf17136645cc642941a9536578f4d6733845e7d0ed36ed4e3e", size = 7597496, upload-time = "2026-04-01T17:55:53.174Z" },
+    { url = "https://files.pythonhosted.org/packages/56/88/eb7f25667c81d16ff55774c685f62d2b622917730b0c822db1d30ff32c11/valkey_glide-2.3.1-cp314-cp314-macosx_10_7_x86_64.whl", hash = "sha256:3d6626e6f9ddfa7f8706023e167b4a2eca8a0f7b7fee1d30f91a83b4811349e4", size = 7383535, upload-time = "2026-04-01T17:55:54.747Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/64/5db032850ae1f8ec345ec5e5c4b0f15c50c8cf88e5a67990491964938cab/valkey_glide-2.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3466a0c113a951d722036704795ff0377eef11a44ab224472f98d99ac2c5ef28", size = 6853286, upload-time = "2026-04-01T17:55:56.96Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/af/4c835ece50d6e1536e96a74a11fe51a1aef8006c6e38544c324a5d4d5637/valkey_glide-2.3.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe53e4808bdac5b4e6482c66583e1980ecf75666b4e4d0984d89e8b693026543", size = 7135821, upload-time = "2026-04-01T17:55:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/c1341d977d0cd3ae812ae620bf0935e51d95e563af5a00562592c10fcc38/valkey_glide-2.3.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1a9662885ea8f3df97a6d873131dea983d42e4735750af368fe2d47e7e44f0c", size = 7595445, upload-time = "2026-04-01T17:56:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5e/0b9cc70a0852c1423bd4e1609500481ffcdd7d11de88ac799c4b4758d39b/valkey_glide-2.3.1-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:5533a090953fd6af4c07b80bd042231540fbd1ede95fff42614750b435f01184", size = 7379308, upload-time = "2026-04-01T17:56:10.508Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3d/68dcc6010a5cd100c360ff57c15cb1e2ff343e81a1ee2630c7cdb57e91b4/valkey_glide-2.3.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:f814ad759e9fdc6c5ced18ddba38cc2a3badb2839ce3555ec9b44beb794096e4", size = 6860135, upload-time = "2026-04-01T17:56:12.698Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a4/6e4b8603ab0217f43721641d08740d3c7ce124d1fc7c9bfb30e967ac1830/valkey_glide-2.3.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dc6dea7ce627a8b166d33232aa7bc7f8dd9d224870235a560bc5d1c4ccec8cb", size = 7136201, upload-time = "2026-04-01T17:56:14.287Z" },
+    { url = "https://files.pythonhosted.org/packages/04/18/8a5a22e8245e48b0bf83a99ac64f289ff62de84ee44315c53a5db8dff69c/valkey_glide-2.3.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1e135bb43e50b1cd6558d93b3108c40a79ce8dc119de883cebb7458d470f629", size = 7594993, upload-time = "2026-04-01T17:56:16.235Z" },
+    { url = "https://files.pythonhosted.org/packages/88/58/a0acca1c36a1481c9f5cf094fc584b1a9f9ad9af927a355400e968cc1f92/valkey_glide-2.3.1-pp311-pypy311_pp73-macosx_10_7_x86_64.whl", hash = "sha256:993c9bffde847fa3d36c6f11e5e50872dd491f245850d7c6ae1bbb8db5bff346", size = 7379554, upload-time = "2026-04-01T17:56:18.12Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/84/02e922bfd7201c9bbf3a4464aaf46e1b5b508852ba05974981a215f34d1b/valkey_glide-2.3.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:918ce3b8a2a3602e82d03f254bad5cc5bd1398eb84dec8eef77aefccc039bd5d", size = 6860268, upload-time = "2026-04-01T17:56:19.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/30/d8e215ab273d9a599ab926a7299e9a1f219120e6248850efb51186107723/valkey_glide-2.3.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28d4cbf00b07db273214488f17d59232baaddd0cc30c26064cf3bf384b03e9cd", size = 7136569, upload-time = "2026-04-01T17:56:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ac/80d29b75115133c3f97dd0fa725eb9598ebcd4217f0ece22ce63dc7dc8f7/valkey_glide-2.3.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d93ef822a524c8f18c1b750f061373d95e842005116ebcf832d166533bf2bc2", size = 7594844, upload-time = "2026-04-01T17:56:23.528Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# feat(vectordb): add Valkey Search provider

## Summary

Adds Valkey Search as a 9th vector database provider, using [valkey-glide](https://github.com/valkey-io/valkey-glide) (the official async-native Valkey client). Targets Valkey 9.1+ with the valkey-search module v1.2.

Closes #603

## Motivation

- **Unique niche**: Ultra-low-latency in-memory vector search — none of the existing 8 providers cover this
- **Operational simplicity**: Teams already running Valkey for caching can add vector search without a separate DB
- **Native hybrid search**: Combines vector + full-text + tag filtering in a single query
- **Managed offerings**: AWS ElastiCache for Valkey includes vector search built-in

## Changes

| File | Change |
|---|---|
| `src/upsonic/vectordb/providers/valkey.py` | New `ValkeyProvider` (~470 lines) |
| `src/upsonic/vectordb/config.py` | New `ValkeyConfig` class |
| `src/upsonic/vectordb/__init__.py` | Added to exports and lazy-import registry |
| `pyproject.toml` | `valkey = ["valkey-glide>=2.3.1"]` group; added to `vectordb` umbrella; widened `protobuf` pin to `<7.0.0` |
| `tests/smoke_tests/vectordb/test_valkey_provider.py` | 24 comprehensive smoke tests |
| `tests/doc_examples/vectordb/valkey_basic.py` | Async usage example |
| `tests/doc_examples/vectordb/valkey_sync.py` | Sync usage example |

## Features

- HNSW and FLAT vector indexes
- Dense (KNN) vector similarity search
- Full-text search
- Hybrid search (RRF fusion)
- Content-based deduplication via `chunk_content_hash`
- TAG field filtering (pipe separator preserves dots/special chars)
- Batched upsert via `asyncio.gather` (respects `batch_size` config)
- Bulk `unlink` for deletes (single round-trip)
- Cluster mode support (`GlideClusterClient`)
- Async-native — no `asyncio.to_thread` wrapping needed
- Sync parity via base class (automatic)

## Requirements

- Valkey 9.1+ with `valkey-search` module loaded (v1.2+)
- `valkey-glide>=2.3.1`

## Note on protobuf

`valkey-glide>=2.3.1` requires `protobuf>=6.20`. The core pin was widened from `>=5.27.2,<6.0.0` to `>=5.27.2,<7.0.0`. No source code in the project imports protobuf directly — it's a transitive dependency of sentry-sdk and opentelemetry, both of which support protobuf 6.x.

## Testing

24 smoke tests passing against Valkey 9.1.0-rc1 with search module v1.2.0. Covers:
- Connection lifecycle (async + sync)
- Collection management (create, exists, delete, recreate)
- Upsert, fetch, delete with full payload validation
- Dense search (KNN) with cosine similarity
- Dense search with TAG filters
- Full-text search
- Hybrid search (RRF)
- Existence checks
- Delete by field (document_name, document_id)
- Metadata update
- Input validation (mismatched lengths → ValueError)
- Error paths (connection refused, missing index)
