### PR TITLE
Add OpenTelemetry GenAI plan span for DeepAgent planning

### DIFF
--- a/src/upsonic/agent/deepagent/tools/planning_toolkit.py
+++ b/src/upsonic/agent/deepagent/tools/planning_toolkit.py
@@ -6,6 +6,7 @@ This is a "cognitive forcing function" - the act of calling the tool and
 structuring the plan induces more careful reasoning in the model.
 """
 
+from contextlib import nullcontext
 from typing import Any, List, Literal, Dict, Optional
 from pydantic import BaseModel, Field, field_validator
 from upsonic.tools import tool, ToolKit
@@ -15,7 +16,7 @@ from upsonic.agent.deepagent.constants import WRITE_TODOS_TOOL_DESCRIPTION
 class Todo(BaseModel):
     """
     A single todo item for task decomposition.
-    
+
     Attributes:
         content: Description of the todo item
         status: Current status (pending, in_progress, completed, cancelled)
@@ -31,7 +32,7 @@ class Todo(BaseModel):
     id: str = Field(
         description="Unique identifier for the todo"
     )
-    
+
     @field_validator('content')
     @classmethod
     def validate_content(cls, v: str) -> str:
@@ -39,7 +40,7 @@ class Todo(BaseModel):
         if not v or not v.strip():
             raise ValueError("Todo content cannot be empty")
         return v.strip()
-    
+
     @field_validator('id')
     @classmethod
     def validate_id(cls, v: str) -> str:
@@ -59,7 +60,7 @@ class TodoList(BaseModel):
         min_length=2,
         description="List of todo items (minimum 2 required)"
     )
-    
+
     @field_validator('todos')
     @classmethod
     def validate_unique_ids(cls, v: List[Todo]) -> List[Todo]:
@@ -73,240 +74,351 @@ class TodoList(BaseModel):
 class PlanningToolKit(ToolKit):
     """
     Planning and task decomposition toolkit for DeepAgent.
-    
+
     Provides the write_todos tool which is a "no-op" cognitive forcing function.
     The tool performs minimal computation - its value comes from forcing the LLM
     to explicitly decompose complex tasks into discrete steps.
-    
+
     Features:
     - Task-specific todo storage
     - Merge-by-ID update strategy
     - Automatic system prompt injection via pipeline step
     - Contextual feedback messages
-    
+
     Usage:
         ```python
         from upsonic import Agent, Task
         from upsonic.agent.deepagent.tools import PlanningToolKit
-        
+
         # Create toolkit (needs reference to current task)
         toolkit = PlanningToolKit()
-        
+
         # The toolkit gets the task reference dynamically during execution
         agent = Agent(model="openai/gpt-4o", tools=[toolkit])
-        
+
         task = Task(description="Complex multi-step task")
         result = agent.do(task)
         ```
     """
-    
+
     def __init__(self, **kwargs: Any):
         """
         Initialize the planning toolkit.
-        
+
         Note: The toolkit will receive task reference dynamically
         during tool execution via the tool call context.
-        
+
         Args:
             **kwargs: ToolKit params (include_tools, exclude_tools, timeout, etc.).
         """
         super().__init__(**kwargs)
         # The current task will be set dynamically during execution
         self._current_task = None
-    
+        self._current_agent = None
+
     def set_current_task(self, task: Any) -> None:
         """
         Set the current task for todo storage.
-        
+
         This is called by the agent before tool execution to ensure
         todos are stored in the correct task instance.
-        
+
         Args:
             task: The task being executed
         """
+        self.set_current_context(task)
+
+    def set_current_context(self, task: Any, agent: Any = None) -> None:
+        """
+        Set the current task and agent for todo storage and tracing.
+
+        Args:
+            task: The task being executed
+            agent: The active agent executing the planning tool
+        """
         self._current_task = task
-    
+        self._current_agent = agent
+
+    def _get_otel_manager(self) -> Any:
+        if self._current_agent is None:
+            return None
+        return getattr(self._current_agent, "_otel", None)
+
+    def _plan_span(self, action: str, todos: Optional[List[Dict[str, Any]]]) -> Any:
+        otel = self._get_otel_manager()
+        if otel is None:
+            return nullcontext(None)
+        return otel.plan_span(
+            agent_name=getattr(self._current_agent, "name", None) or getattr(self._current_agent, "role", None),
+            agent_id=getattr(self._current_agent, "agent_id", None),
+            action=action,
+            input_todos=todos,
+        )
+
+    def _set_plan_result(
+        self,
+        span: Any,
+        *,
+        success: bool,
+        action: str,
+        output: Optional[str] = None,
+        error: Optional[Exception] = None,
+    ) -> None:
+        otel = self._get_otel_manager()
+        if otel is None:
+            return
+        otel.set_plan_result(
+            span,
+            success=success,
+            action=action,
+            todo_count=self._current_todo_count(),
+            status_counts=self._current_status_counts(),
+            output=output,
+            error=error,
+        )
+
+    def _current_plan_action(self) -> str:
+        if self._current_task is None:
+            return "validate"
+        current_todos = getattr(self._current_task, '_task_todos', None)
+        return "create" if current_todos is None or len(current_todos) == 0 else "update"
+
+    def _current_todo_count(self) -> int:
+        if self._current_task is None:
+            return 0
+        current_todos = getattr(self._current_task, '_task_todos', None)
+        return len(current_todos) if current_todos else 0
+
+    def _current_status_counts(self) -> Dict[str, int]:
+        if self._current_task is None:
+            return {}
+        current_todos = getattr(self._current_task, '_task_todos', None)
+        if not current_todos:
+            return {}
+        status_counts: Dict[str, int] = {}
+        for todo in current_todos:
+            status = getattr(todo, "status", None)
+            if status:
+                status_counts[status] = status_counts.get(status, 0) + 1
+        return status_counts
+
     @tool
     async def write_todos(self, todos: Optional[List[Dict[str, Any]]] = None) -> str:
         """Placeholder docstring - will be replaced."""
-        # Validate we have a current task
-        if self._current_task is None:
-            return (
-                "❌ Error: No active task found.\n\n"
-                "The write_todos tool requires an active task context.\n"
-                "This is an internal error - please report this issue."
-            )
-        
-        # Validate todos parameter is provided
-        if todos is None or not todos:
-            return (
-                "❌ Error: Missing 'todos' parameter.\n\n"
-                "The write_todos tool requires a 'todos' parameter with a list of todo items.\n"
-                "Each todo must have: 'content', 'status', and 'id' fields.\n"
-                "Minimum 2 todos required.\n\n"
-                "Example:\n"
-                "write_todos([\n"
-                '  {"content": "Research topic", "status": "pending", "id": "1"},\n'
-                '  {"content": "Write report", "status": "pending", "id": "2"}\n'
-                "])"
-            )
-        
-        try:
-            # Get current todos from task (if any)
-            current_todos = getattr(self._current_task, '_task_todos', None)
-            
-            is_first_call = current_todos is None or len(current_todos) == 0
-            
-            # For first call, enforce minimum 2 todos
-            # For updates, allow any number since we're merging with existing plan
-            if is_first_call:
-                # Validate with TodoList (enforces min 2 todos)
-                todo_list = TodoList(todos=[Todo(**t) for t in todos])
-                from upsonic.utils.printing import planning_todo_list
-                planning_todo_list(todo_list, debug=True)
-                new_todos = todo_list.todos
-            else:
-                # For updates, just validate individual todos (no minimum requirement)
-                new_todos = [Todo(**t) for t in todos]
-                
-                # Validate unique IDs among the new todos
-                new_ids = [todo.id for todo in new_todos]
-                if len(new_ids) != len(set(new_ids)):
-                    raise ValueError("Todo IDs must be unique")
-            
-            if is_first_call:
-                # First call: Store all todos
-                self._current_task._task_todos = new_todos
-                
-                # Format response for first call
-                todo_summary = []
-                for i, todo in enumerate(new_todos, 1):
-                    todo_summary.append(f"{i}. [{todo.status}] {todo.content}")
-                
-                response = f"✅ Plan created with {len(new_todos)} tasks:\n\n"
-                response += "\n".join(todo_summary)
-                response += "\n\nYou can now proceed with your work. Update the plan as you progress."
-                
+        action = self._current_plan_action()
+        with self._plan_span(action, todos) as plan_span:
+            # Validate we have a current task
+            if self._current_task is None:
+                response = (
+                    "❌ Error: No active task found.\n\n"
+                    "The write_todos tool requires an active task context.\n"
+                    "This is an internal error - please report this issue."
+                )
+                self._set_plan_result(
+                    plan_span,
+                    success=False,
+                    action=action,
+                    output=response,
+                    error=RuntimeError(response),
+                )
                 return response
-            else:
-                # Update call: Merge by ID
-                # Create a dict of current todos by ID for fast lookup
-                current_by_id = {todo.id: todo for todo in current_todos}
-                
-                # Merge new todos
-                updated_count = 0
-                added_count = 0
-                
-                for new_todo in new_todos:
-                    if new_todo.id in current_by_id:
-                        # Update existing todo
-                        old_todo = current_by_id[new_todo.id]
-                        
-                        # Check what changed
-                        status_changed = old_todo.status != new_todo.status
-                        content_changed = old_todo.content != new_todo.content
-                        
-                        if status_changed or content_changed:
-                            # Update the todo
+
+            # Validate todos parameter is provided
+            if todos is None or not todos:
+                response = (
+                    "❌ Error: Missing 'todos' parameter.\n\n"
+                    "The write_todos tool requires a 'todos' parameter with a list of todo items.\n"
+                    "Each todo must have: 'content', 'status', and 'id' fields.\n"
+                    "Minimum 2 todos required.\n\n"
+                    "Example:\n"
+                    "write_todos([\n"
+                    '  {"content": "Research topic", "status": "pending", "id": "1"},\n'
+                    '  {"content": "Write report", "status": "pending", "id": "2"}\n'
+                    "])"
+                )
+                self._set_plan_result(
+                    plan_span,
+                    success=False,
+                    action=action,
+                    output=response,
+                    error=ValueError("Missing 'todos' parameter"),
+                )
+                return response
+
+            try:
+                # Get current todos from task (if any)
+                current_todos = getattr(self._current_task, '_task_todos', None)
+
+                is_first_call = current_todos is None or len(current_todos) == 0
+                action = "create" if is_first_call else "update"
+
+                # For first call, enforce minimum 2 todos
+                # For updates, allow any number since we're merging with existing plan
+                if is_first_call:
+                    # Validate with TodoList (enforces min 2 todos)
+                    todo_list = TodoList(todos=[Todo(**t) for t in todos])
+                    from upsonic.utils.printing import planning_todo_list
+                    planning_todo_list(todo_list, debug=True)
+                    new_todos = todo_list.todos
+                else:
+                    # For updates, just validate individual todos (no minimum requirement)
+                    new_todos = [Todo(**t) for t in todos]
+
+                    # Validate unique IDs among the new todos
+                    new_ids = [todo.id for todo in new_todos]
+                    if len(new_ids) != len(set(new_ids)):
+                        raise ValueError("Todo IDs must be unique")
+
+                if is_first_call:
+                    # First call: Store all todos
+                    self._current_task._task_todos = new_todos
+
+                    # Format response for first call
+                    todo_summary = []
+                    for i, todo in enumerate(new_todos, 1):
+                        todo_summary.append(f"{i}. [{todo.status}] {todo.content}")
+
+                    response = f"✅ Plan created with {len(new_todos)} tasks:\n\n"
+                    response += "\n".join(todo_summary)
+                    response += "\n\nYou can now proceed with your work. Update the plan as you progress."
+                    self._set_plan_result(plan_span, success=True, action=action, output=response)
+                    return response
+                else:
+                    # Update call: Merge by ID
+                    # Create a dict of current todos by ID for fast lookup
+                    current_by_id = {todo.id: todo for todo in current_todos}
+
+                    # Merge new todos
+                    updated_count = 0
+                    added_count = 0
+
+                    for new_todo in new_todos:
+                        if new_todo.id in current_by_id:
+                            # Update existing todo
+                            old_todo = current_by_id[new_todo.id]
+
+                            # Check what changed
+                            status_changed = old_todo.status != new_todo.status
+                            content_changed = old_todo.content != new_todo.content
+
+                            if status_changed or content_changed:
+                                # Update the todo
+                                current_by_id[new_todo.id] = new_todo
+                                updated_count += 1
+                        else:
+                            # Add new todo
                             current_by_id[new_todo.id] = new_todo
-                            updated_count += 1
-                    else:
-                        # Add new todo
-                        current_by_id[new_todo.id] = new_todo
-                        added_count += 1
-                
-                # Rebuild the list (maintain order by ID)
-                self._current_task._task_todos = list(current_by_id.values())
-                
-                # Format response for update
-                response = "✅ Plan updated:\n"
-                
-                if updated_count > 0:
-                    response += f"   • Updated: {updated_count} task(s)\n"
-                if added_count > 0:
-                    response += f"   • Added: {added_count} new task(s)\n"
-                
-                if updated_count == 0 and added_count == 0:
-                    response += "   • No changes (all todos already exist with same values)\n"
-                
-                response += f"\nCurrent plan: {len(self._current_task._task_todos)} total task(s)"
-                
-                # Show current status breakdown
-                status_counts = {}
-                for todo in self._current_task._task_todos:
-                    status_counts[todo.status] = status_counts.get(todo.status, 0) + 1
-                
-                status_parts = []
-                if status_counts.get("completed", 0) > 0:
-                    status_parts.append(f"{status_counts['completed']} completed")
-                if status_counts.get("in_progress", 0) > 0:
-                    status_parts.append(f"{status_counts['in_progress']} in progress")
-                if status_counts.get("pending", 0) > 0:
-                    status_parts.append(f"{status_counts['pending']} pending")
-                if status_counts.get("cancelled", 0) > 0:
-                    status_parts.append(f"{status_counts['cancelled']} cancelled")
-                
-                if status_parts:
-                    response += f" ({', '.join(status_parts)})"
-                # Print update visualization
-                from upsonic.utils.printing import planning_todo_update
-                planning_todo_update(
-                    self._current_task._task_todos,
-                    updated_count,
-                    added_count,
-                    status_counts,
-                    debug=True
+                            added_count += 1
+
+                    # Rebuild the list (maintain order by ID)
+                    self._current_task._task_todos = list(current_by_id.values())
+
+                    # Format response for update
+                    response = "✅ Plan updated:\n"
+
+                    if updated_count > 0:
+                        response += f"   • Updated: {updated_count} task(s)\n"
+                    if added_count > 0:
+                        response += f"   • Added: {added_count} new task(s)\n"
+
+                    if updated_count == 0 and added_count == 0:
+                        response += "   • No changes (all todos already exist with same values)\n"
+
+                    response += f"\nCurrent plan: {len(self._current_task._task_todos)} total task(s)"
+
+                    # Show current status breakdown
+                    status_counts = {}
+                    for todo in self._current_task._task_todos:
+                        status_counts[todo.status] = status_counts.get(todo.status, 0) + 1
+
+                    status_parts = []
+                    if status_counts.get("completed", 0) > 0:
+                        status_parts.append(f"{status_counts['completed']} completed")
+                    if status_counts.get("in_progress", 0) > 0:
+                        status_parts.append(f"{status_counts['in_progress']} in progress")
+                    if status_counts.get("pending", 0) > 0:
+                        status_parts.append(f"{status_counts['pending']} pending")
+                    if status_counts.get("cancelled", 0) > 0:
+                        status_parts.append(f"{status_counts['cancelled']} cancelled")
+
+                    if status_parts:
+                        response += f" ({', '.join(status_parts)})"
+                    # Print update visualization
+                    from upsonic.utils.printing import planning_todo_update
+                    planning_todo_update(
+                        self._current_task._task_todos,
+                        updated_count,
+                        added_count,
+                        status_counts,
+                        debug=True
+                    )
+
+                    self._set_plan_result(plan_span, success=True, action=action, output=response)
+                    return response
+
+            except ValueError as e:
+                # Pydantic validation error
+                error_msg = str(e)
+
+                # Provide helpful guidance based on error type
+                if "too_short" in error_msg.lower() or "at least 2" in error_msg.lower() or "min_length" in error_msg.lower() or "minimum" in error_msg.lower():
+                    response = (
+                        "❌ Error: Minimum 2 todos required\n\n"
+                        "The write_todos tool requires at least 2 tasks for proper planning.\n"
+                        "If you only have 1 task, consider breaking it down into subtasks,\n"
+                        "or just proceed without using the planning tool."
+                    )
+                elif "unique" in error_msg.lower():
+                    response = (
+                        "❌ Error: Todo IDs must be unique\n\n"
+                        "Each todo must have a unique ID.\n"
+                        "Please ensure all IDs are different (e.g., '1', '2', '3')."
+                    )
+                elif "empty" in error_msg.lower():
+                    response = (
+                        "❌ Error: Todo content or ID cannot be empty\n\n"
+                        "Each todo must have:\n"
+                        "- content: Non-empty description\n"
+                        "- id: Non-empty identifier\n"
+                        "- status: One of: pending, in_progress, completed, cancelled"
+                    )
+                else:
+                    response = f"❌ Error: Invalid todo format\n\n{error_msg}"
+                self._set_plan_result(
+                    plan_span,
+                    success=False,
+                    action=action,
+                    output=response,
+                    error=e,
                 )
-                
                 return response
-                
-        except ValueError as e:
-            # Pydantic validation error
-            error_msg = str(e)
-            
-            # Provide helpful guidance based on error type
-            if "too_short" in error_msg.lower() or "at least 2" in error_msg.lower() or "min_length" in error_msg.lower() or "minimum" in error_msg.lower():
-                return (
-                    "❌ Error: Minimum 2 todos required\n\n"
-                    "The write_todos tool requires at least 2 tasks for proper planning.\n"
-                    "If you only have 1 task, consider breaking it down into subtasks,\n"
-                    "or just proceed without using the planning tool."
+
+            except Exception as e:
+                response = f"❌ Error creating plan: {str(e)}"
+                self._set_plan_result(
+                    plan_span,
+                    success=False,
+                    action=action,
+                    output=response,
+                    error=e,
                 )
-            elif "unique" in error_msg.lower():
-                return (
-                    "❌ Error: Todo IDs must be unique\n\n"
-                    "Each todo must have a unique ID.\n"
-                    "Please ensure all IDs are different (e.g., '1', '2', '3')."
-                )
-            elif "empty" in error_msg.lower():
-                return (
-                    "❌ Error: Todo content or ID cannot be empty\n\n"
-                    "Each todo must have:\n"
-                    "- content: Non-empty description\n"
-                    "- id: Non-empty identifier\n"
-                    "- status: One of: pending, in_progress, completed, cancelled"
-                )
-            else:
-                return f"❌ Error: Invalid todo format\n\n{error_msg}"
-        
-        except Exception as e:
-            return f"❌ Error creating plan: {str(e)}"
-    
+                return response
+
     def get_current_todos(self) -> List[Dict[str, Any]]:
         """
         Get the current todo list from the active task.
-        
+
         Returns:
             List of todo dictionaries with content, status, and id keys
         """
         if self._current_task is None:
             return []
-        
+
         current_todos = getattr(self._current_task, '_task_todos', None)
-        
+
         if not current_todos:
             return []
-        
+
         return [
             {
                 "id": todo.id,

--- a/src/upsonic/agent/otel_manager.py
+++ b/src/upsonic/agent/otel_manager.py
@@ -43,6 +43,15 @@ ATTR_STEP_NAME: str = "upsonic.step.name"
 ATTR_STEP_DESCRIPTION: str = "upsonic.step.description"
 ATTR_STEP_STATUS: str = "upsonic.step.status"
 ATTR_STEP_EXECUTION_TIME: str = "upsonic.step.execution_time"
+ATTR_PLAN_ACTION: str = "upsonic.plan.action"
+ATTR_PLAN_INPUT: str = "upsonic.plan.input"
+ATTR_PLAN_OUTPUT: str = "upsonic.plan.output"
+ATTR_PLAN_TODO_COUNT: str = "upsonic.plan.todo_count"
+ATTR_PLAN_STATUS_PREFIX: str = "upsonic.plan.status"
+
+GEN_AI_OPERATION_NAME: str = "gen_ai.operation.name"
+GEN_AI_AGENT_NAME: str = "gen_ai.agent.name"
+GEN_AI_AGENT_ID: str = "gen_ai.agent.id"
 
 # Additional run-level metrics
 ATTR_USAGE_REQUESTS: str = "upsonic.usage.requests"
@@ -73,6 +82,18 @@ LF_USER_ID: str = "langfuse.user.id"
 LF_SESSION_ID: str = "langfuse.session.id"
 GENERIC_USER_ID: str = "user.id"
 GENERIC_SESSION_ID: str = "session.id"
+_PLAN_OPERATION: str = "plan"
+_PLAN_STATUSES: tuple[str, ...] = ("pending", "in_progress", "completed", "cancelled")
+_CONTENT_ATTRIBUTE_LIMIT: int = 5000
+
+
+def _serialize_content_attribute(value: Any) -> str:
+    """Serialize arbitrary content to an OTel-safe bounded string attribute."""
+    try:
+        serialized = _json.dumps(value, default=str)
+    except Exception:
+        serialized = str(value)
+    return serialized[:_CONTENT_ATTRIBUTE_LIMIT]
 
 
 def _set_baggage(
@@ -309,6 +330,41 @@ class AgentOTelManager:
             attributes=attrs,
         )
 
+    def plan_span(
+        self,
+        *,
+        agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        action: Optional[str] = None,
+        input_todos: Optional[Any] = None,
+    ) -> Any:
+        """Create a GenAI ``plan`` span, or a no-op context manager."""
+        if self._settings is None:
+            return nullcontext(None)
+
+        from opentelemetry.trace import SpanKind
+
+        span_name = f"plan {agent_name}" if agent_name else "plan"
+        attrs: Dict[str, Any] = {
+            GEN_AI_OPERATION_NAME: _PLAN_OPERATION,
+        }
+        if agent_name:
+            attrs[GEN_AI_AGENT_NAME] = agent_name
+        if agent_id:
+            attrs[GEN_AI_AGENT_ID] = agent_id
+        if action:
+            attrs[ATTR_PLAN_ACTION] = action
+
+        include_content: bool = getattr(self._settings, "include_content", True)
+        if include_content and input_todos is not None:
+            attrs[ATTR_PLAN_INPUT] = _serialize_content_attribute(input_todos)
+
+        return self._settings.tracer.start_as_current_span(
+            span_name,
+            kind=SpanKind.INTERNAL,
+            attributes=attrs,
+        )
+
     def pipeline_span(
         self,
         total_steps: int,
@@ -453,6 +509,48 @@ class AgentOTelManager:
             _set_status_ok(span)
         elif error is not None:
             self.record_error(span, error)
+
+    def set_plan_result(
+        self,
+        span: Any,
+        *,
+        success: bool,
+        todo_count: Optional[int] = None,
+        status_counts: Optional[Dict[str, int]] = None,
+        action: Optional[str] = None,
+        output: Optional[Any] = None,
+        error: Optional[Exception] = None,
+    ) -> None:
+        """Set result attributes on a GenAI ``plan`` span."""
+        if not _is_recording(span):
+            return
+
+        attrs: Dict[str, Any] = {}
+        if action:
+            attrs[ATTR_PLAN_ACTION] = action
+        if todo_count is not None:
+            attrs[ATTR_PLAN_TODO_COUNT] = todo_count
+        if status_counts:
+            for status in _PLAN_STATUSES:
+                count = status_counts.get(status)
+                if count is not None:
+                    attrs[f"{ATTR_PLAN_STATUS_PREFIX}.{status}"] = count
+
+        include_content: bool = (
+            getattr(self._settings, "include_content", True)
+            if self._settings is not None
+            else True
+        )
+        if include_content and output is not None:
+            attrs[ATTR_PLAN_OUTPUT] = _serialize_content_attribute(output)
+
+        if attrs:
+            span.set_attributes(attrs)
+
+        if success:
+            _set_status_ok(span)
+        else:
+            self.record_error(span, error or RuntimeError("plan failed"))
 
     def set_step_result(
         self,

--- a/src/upsonic/agent/pipeline/steps.py
+++ b/src/upsonic/agent/pipeline/steps.py
@@ -478,7 +478,10 @@ class ToolSetupStep(Step):
             agent._setup_task_tools(task)
             
             if hasattr(agent, '_planning_toolkit') and agent._planning_toolkit:
-                agent._planning_toolkit.set_current_task(task)
+                if hasattr(agent._planning_toolkit, "set_current_context"):
+                    agent._planning_toolkit.set_current_context(task, agent)
+                else:
+                    agent._planning_toolkit.set_current_task(task)
             
             tool_names: list = []
             has_mcp: bool = False

--- a/tests/unit_tests/agent/test_otel_instrumentation.py
+++ b/tests/unit_tests/agent/test_otel_instrumentation.py
@@ -14,6 +14,7 @@ Covers:
 Run with: uv run pytest tests/unit_tests/agent/test_otel_instrumentation.py -v -s
 """
 
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +30,24 @@ from upsonic.agent.otel_manager import AgentOTelManager
 from upsonic.agent.pipeline.manager import PipelineManager
 from upsonic.agent.pipeline.step import StepResult, StepStatus
 from upsonic.usage import RunUsage, RequestUsage
+
+
+def _make_otel_capture(include_content: bool = True) -> tuple[Any, Any, Any, InstrumentationSettings]:
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter_provider = MeterProvider()
+    settings = InstrumentationSettings(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        include_content=include_content,
+    )
+    return exporter, tracer_provider, meter_provider, settings
 
 
 def _make_mock_model(model: Any = "openai/gpt-4o", **_kwargs: Any) -> MagicMock:
@@ -282,6 +301,161 @@ class TestSpanContextManagers:
     def test_pipeline_manager_resolves_noop_otel(self) -> None:
         pm = PipelineManager(agent=Agent("openai/gpt-4o"))
         assert not pm._otel.enabled
+
+
+class TestPlanSpans:
+    """Test GenAI plan span instrumentation for DeepAgent planning."""
+
+    def test_plan_span_noop(self) -> None:
+        otel = _make_otel(instrument=False)
+        with otel.plan_span(agent_name="Planner") as span:
+            assert span is None
+
+    def test_plan_result_omits_content_when_disabled(self) -> None:
+        settings = InstrumentationSettings(include_content=False)
+        otel = AgentOTelManager(settings)
+        span = RecordingSpan()
+
+        otel.set_plan_result(
+            span,
+            success=True,
+            todo_count=2,
+            status_counts={"pending": 2},
+            action="create",
+            output="hidden plan output",
+        )
+
+        assert span.attrs["upsonic.plan.todo_count"] == 2
+        assert span.attrs["upsonic.plan.status.pending"] == 2
+        assert span.attrs["upsonic.plan.action"] == "create"
+        assert "upsonic.plan.output" not in span.attrs
+
+    @pytest.mark.asyncio
+    async def test_planning_toolkit_write_todos_emits_plan_span(self) -> None:
+        from opentelemetry.trace import StatusCode
+        from upsonic.agent.deepagent.tools.planning_toolkit import PlanningToolKit
+
+        exporter, tracer_provider, meter_provider, settings = _make_otel_capture()
+        try:
+            toolkit = PlanningToolKit()
+            task = SimpleNamespace()
+            agent = SimpleNamespace(
+                _otel=AgentOTelManager(settings),
+                name="PlannerAgent",
+                agent_id="agent-123",
+            )
+            toolkit.set_current_context(task, agent)
+
+            response = await toolkit.write_todos([
+                {"content": "Research", "status": "pending", "id": "1"},
+                {"content": "Write", "status": "pending", "id": "2"},
+            ])
+
+            assert "Plan created" in response
+            plan_spans = [
+                span
+                for span in exporter.get_finished_spans()
+                if span.attributes.get("gen_ai.operation.name") == "plan"
+            ]
+            assert len(plan_spans) == 1
+            plan_span = plan_spans[0]
+            assert plan_span.name == "plan PlannerAgent"
+            assert plan_span.attributes["gen_ai.agent.name"] == "PlannerAgent"
+            assert plan_span.attributes["gen_ai.agent.id"] == "agent-123"
+            assert plan_span.attributes["upsonic.plan.action"] == "create"
+            assert plan_span.attributes["upsonic.plan.todo_count"] == 2
+            assert plan_span.attributes["upsonic.plan.status.pending"] == 2
+            assert plan_span.status.status_code == StatusCode.OK
+        finally:
+            tracer_provider.shutdown()
+            meter_provider.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_planning_toolkit_validation_error_marks_plan_span_error(self) -> None:
+        from opentelemetry.trace import StatusCode
+        from upsonic.agent.deepagent.tools.planning_toolkit import PlanningToolKit
+
+        exporter, tracer_provider, meter_provider, settings = _make_otel_capture()
+        try:
+            toolkit = PlanningToolKit()
+            task = SimpleNamespace()
+            agent = SimpleNamespace(_otel=AgentOTelManager(settings), name="PlannerAgent")
+            toolkit.set_current_context(task, agent)
+
+            response = await toolkit.write_todos([])
+
+            assert "Missing 'todos' parameter" in response
+            plan_spans = [
+                span
+                for span in exporter.get_finished_spans()
+                if span.attributes.get("gen_ai.operation.name") == "plan"
+            ]
+            assert len(plan_spans) == 1
+            assert plan_spans[0].attributes["upsonic.plan.action"] == "create"
+            assert plan_spans[0].status.status_code == StatusCode.ERROR
+        finally:
+            tracer_provider.shutdown()
+            meter_provider.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_deepagent_write_todos_tool_emits_child_plan_span(self) -> None:
+        from upsonic import Task
+        from upsonic.agent.deepagent import DeepAgent
+        from upsonic.agent.pipeline.steps import ToolSetupStep
+        from upsonic.messages.messages import ToolCallPart
+        from upsonic.run.pipeline.stats import PipelineExecutionStats
+
+        exporter, tracer_provider, meter_provider, settings = _make_otel_capture()
+        try:
+            agent = DeepAgent(
+                model="openai/gpt-4o",
+                name="RuntimePlanner",
+                instrument=settings,
+                enable_planning=True,
+                enable_filesystem=False,
+                enable_subagents=False,
+            )
+            task = Task("Create a short execution plan")
+            context = SimpleNamespace(
+                is_streaming=False,
+                events=[],
+                run_id="run-1",
+                step_results=[],
+                execution_stats=PipelineExecutionStats(total_steps=1),
+            )
+            agent.current_task = task
+
+            await ToolSetupStep().execute(context, task, agent, agent.model, 0)
+            result = await agent._execute_tool_calls([
+                ToolCallPart(
+                    tool_name="write_todos",
+                    args={
+                        "todos": [
+                            {"content": "Research", "status": "pending", "id": "1"},
+                            {"content": "Write", "status": "pending", "id": "2"},
+                        ]
+                    },
+                    tool_call_id="call_plan",
+                )
+            ])
+
+            assert len(result) == 1
+            assert result[0].tool_name == "write_todos"
+            spans = exporter.get_finished_spans()
+            tool_span = next(span for span in spans if span.name == "tool.execute")
+            plan_span = next(
+                span
+                for span in spans
+                if span.attributes.get("gen_ai.operation.name") == "plan"
+            )
+
+            assert plan_span.parent is not None
+            assert plan_span.parent.span_id == tool_span.context.span_id
+            assert plan_span.attributes["upsonic.plan.action"] == "create"
+            assert plan_span.attributes["upsonic.plan.todo_count"] == 2
+        finally:
+            tracer_provider.shutdown()
+            meter_provider.shutdown()
 
 
 class TestErrorRecording:


### PR DESCRIPTION
Adds runtime OpenTelemetry instrumentation for DeepAgent planning by emitting a GenAI plan span around write_todos.

  The span sets gen_ai.operation.name = "plan", captures agent identity when available, records plan action, todo count, and status counts, respects
  include_content, records success/error status, and nests under the existing tool.execute span when invoked through the real DeepAgent tool path.

  This follows the GenAI semantic convention added in open-telemetry/semantic-conventions-genai#97.

  Validation:
  - uv run pytest tests/unit_tests/agent/test_otel_instrumentation.py -q
  - uv run pytest tests/unit_tests/agent/test_deep_agent.py -q
  - uv run pytest tests/unit_tests/agent/test_otel_instrumentation.py tests/unit_tests/agent/test_deep_agent.py -q
  - Live Claude e2e with anthropic/claude-haiku-4-5-20251001: emitted one plan span under tool.execute
  - git diff --check