### PR TITLE
docs: add SECURITY.md with responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Responsible Disclosure
+
+If you believe you have found a security vulnerability in Upsonic Platform, please report it to `security@upsonic.co`.
+
+Please include:
+
+- A clear description of the issue and its impact.
+- Steps to reproduce the behavior.
+- Any proof-of-concept code, requests, or screenshots that help us validate the report.
+- Your preferred contact information for follow-up.
+
+## Scope
+
+This policy covers security vulnerabilities in this repository and the software it ships.
+
+Please do not use public issues, pull requests, or other public channels for vulnerability reports.
+
+## Response Expectations
+
+We will acknowledge receipt of a report within 7 business days.
+
+We aim to investigate validated reports promptly and target coordinated disclosure within 90 days, depending on severity and remediation complexity.
+
+## Researcher Expectations
+
+Please act in good faith and avoid:
+
+- Accessing, modifying, or deleting data that does not belong to you.
+- Disrupting service availability or degrading the experience for other users.
+- Using social engineering, spam, or physical attacks.
+- Publicly disclosing a vulnerability before we have had a reasonable opportunity to investigate and remediate it.
+
+We will treat good-faith security research intended to improve the safety of our systems as responsible disclosure.


### PR DESCRIPTION
Adds a SECURITY.md to the repository root defining how to report vulnerabilities, what's in scope, response timelines (7-day acknowledgement, 90-day disclosure target), and researcher expectations.